### PR TITLE
integrate work on JSON zippers and pathing

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,8 +12,8 @@
         clojure.java-time {:mvn/version "0.3.2"}
         ;; org.threeten/threeten-extra {:mvn/version "1.4"}
         org.apache.jena/jena-iri {:mvn/version "3.13.1"}
-
-        }
+        ;; JSON Path Parser built with
+        org.blancas/kern {:mvn/version "1.1.0"}}
  :mvn/repos {"jitpack" {:url "https://jitpack.io"}} ;; there's a wack repo in project pan
  :aliases
  {:cli {:extra-paths ["src/cli"]

--- a/dev-resources/xapi/statements/long.json
+++ b/dev-resources/xapi/statements/long.json
@@ -1,0 +1,131 @@
+{
+    "id": "6690e6c9-3ef0-4ed3-8b37-7f3964730bee",
+    "actor": {
+        "name": "Team PB",
+        "mbox": "mailto:teampb@example.com",
+        "member": [
+            {
+                "name": "Andrew Downes",
+                "account": {
+                    "homePage": "http://www.example.com",
+                    "name": "13936749"
+                },
+                "objectType": "Agent"
+            },
+            {
+                "name": "Toby Nichols",
+                "openid": "http://toby.openid.example.org/",
+                "objectType": "Agent"
+            },
+            {
+                "name": "Ena Hills",
+                "mbox_sha1sum": "ebd31e95054c018b10727ccffd2ef2ec3a016ee9",
+                "objectType": "Agent"
+            }
+        ],
+        "objectType": "Group"
+    },
+    "verb": {
+        "id": "http://adlnet.gov/expapi/verbs/attended",
+        "display": {
+            "en-GB": "attended",
+            "en-US": "attended"
+        }
+    },
+    "result": {
+        "extensions": {
+            "http://example.com/profiles/meetings/resultextensions/minuteslocation": "X:\\meetings\\minutes\\examplemeeting.one"
+        },
+        "success": true,
+        "completion": true,
+        "response": "We agreed on some example actions.",
+        "duration": "PT1H0M0S"
+    },
+    "context": {
+        "registration": "ec531277-b57b-4c15-8d91-d292c5b2b8f7",
+        "contextActivities": {
+            "parent": [
+                {
+                    "id": "http://www.example.com/meetings/series/267",
+                    "objectType": "Activity"
+                }
+            ],
+            "category": [
+                {
+                    "id": "http://www.example.com/meetings/categories/teammeeting",
+                    "objectType": "Activity",
+                    "definition": {
+			            "name": {
+			                "en": "team meeting"
+			            },
+			            "description": {
+			                "en": "A category of meeting used for regular team meetings."
+			            },
+			            "type": "http://example.com/expapi/activities/meetingcategory"
+			        }
+                }
+            ],
+            "other": [
+                {
+                    "id": "http://www.example.com/meetings/occurances/34257",
+                    "objectType": "Activity"
+                },
+                {
+                    "id": "http://www.example.com/meetings/occurances/3425567",
+                    "objectType": "Activity"
+                }
+            ]
+        },
+        "instructor" :
+        {
+        	"name": "Andrew Downes",
+            "account": {
+                "homePage": "http://www.example.com",
+                "name": "13936749"
+            },
+            "objectType": "Agent"
+        },
+        "team":
+        {
+        	"name": "Team PB",
+        	"mbox": "mailto:teampb@example.com",
+        	"objectType": "Group"
+        },
+        "platform" : "Example virtual meeting software",
+        "language" : "tlh",
+        "statement" : {
+        	"objectType":"StatementRef",
+        	"id" :"6690e6c9-3ef0-4ed3-8b37-7f3964730bee"
+        }
+
+    },
+    "timestamp": "2013-05-18T05:32:34.804Z",
+    "stored": "2013-05-18T05:32:34.804Z",
+    "authority": {
+        "account": {
+            "homePage": "http://cloud.scorm.com/",
+            "name": "anonymous"
+        },
+        "objectType": "Agent"
+    },
+    "version": "1.0.0",
+    "object": {
+        "id": "http://www.example.com/meetings/occurances/34534",
+        "definition": {
+            "extensions": {
+                "http://example.com/profiles/meetings/activitydefinitionextensions/room": {"name": "Kilby", "id" : "http://example.com/rooms/342"}
+            },
+            "name": {
+                "en-GB": "example meeting",
+                "en-US": "example meeting"
+            },
+            "description": {
+                "en-GB": "An example meeting that happened on a specific occasion with certain people present.",
+                "en-US": "An example meeting that happened on a specific occasion with certain people present."
+            },
+            "type": "http://adlnet.gov/expapi/activities/meeting",
+            "moreInfo": "http://virtualmeeting.example.com/345256"
+        },
+        "objectType": "Activity"
+    }
+}

--- a/src/main/com/yetanalytics/datasim/json.clj
+++ b/src/main/com/yetanalytics/datasim/json.clj
@@ -1,0 +1,28 @@
+(ns com.yetanalytics.datasim.json
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::any
+  (s/nilable
+   (s/or :scalar
+         (s/or :string
+               string?
+               :number
+               (s/or :double
+                     (s/double-in :infinite? false :NaN? false
+                                  :max 1000.0 :min -1000.0)
+                     :int
+                     int?)
+               :boolean
+               boolean?)
+         :coll
+         (s/or :map
+               (s/map-of
+                string?
+                ::any
+                :gen-max 4)
+               :vector
+               (s/coll-of
+                ::any
+                :kind vector?
+                :into []
+                :gen-max 4)))))

--- a/src/main/com/yetanalytics/datasim/json/path.clj
+++ b/src/main/com/yetanalytics/datasim/json/path.clj
@@ -1,0 +1,162 @@
+(ns com.yetanalytics.datasim.json.path
+  (:require [blancas.kern.core :as k]
+            [blancas.kern.lexer.basic :as kl]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::root
+  #{'$})
+
+(def root
+  (k/<$>
+   (constantly '$)
+   (k/sym* \$)))
+
+(s/def ::wildcard
+  #{'*})
+
+(def wildcard
+  (k/<$>
+   (constantly '*)
+   (k/sym* \*)))
+
+(s/def ::keyset
+  (s/or :keys (s/every string?
+                       :type set?
+                       :into #{}
+                       :min-count 1)
+        :indices (s/every int?
+                          :type set?
+                          :into #{}
+                          :min-count 1)))
+
+(def index
+  (k/<$>
+   (fn [^String x]
+     (Long/parseLong x))
+   (k/<+>
+    (k/optional (k/sym* \-))
+    kl/dec-lit)))
+
+(s/def :range/start
+  int?)
+
+(s/def :range/end
+  int?)
+
+(s/def :range/step
+  int?)
+
+
+
+(defrecord RangeSpec [start end step])
+
+(s/def ::range
+  (s/keys :req-un [:range/start
+                   :range/end
+                   :range/step]))
+
+(def index-range
+  (k/bind [start (k/option 0
+                           index)
+           _ kl/colon
+           end (k/option Long/MAX_VALUE
+                         index)
+           _ (k/optional kl/colon)
+           step (k/option 1
+                          index)]
+          (k/return
+           (->RangeSpec (if (number? start)
+                          start
+                          (Long/parseLong start))
+                        (if (number? end)
+                          end
+                          (Long/parseLong end))
+
+                        (if (number? step)
+                          step
+                          (Long/parseLong step))))))
+
+(defn escaped-by
+  [c & [charset-p]]
+  (k/>> (k/sym* c)
+        (or charset-p k/any-char)))
+
+(def escaped-char
+  (escaped-by (char 92)))
+
+(def safe-char
+  (k/none-of* (str
+               ;; double-quote
+               (char 34)
+               ;; single quote
+               (char 39)
+               ;; escape char
+               (char 92))))
+
+(def json-key
+  (k/<+>
+   (k/many
+    (k/<|>
+     escaped-char
+     safe-char))))
+
+(def json-key-lit
+  (k/<+>
+   (k/between (k/sym* \') json-key)))
+
+(defn union-of1
+  "A comma separated union of at least 1 of something.
+   Returns a set."
+  [p]
+  (k/<$>
+   set
+   (k/sep-by1 (k/sym* \,) p)))
+
+(def child-normal
+  "Normal bracket-style child"
+  (kl/brackets
+   (k/<|>
+    wildcard
+    (k/<:> index-range)
+    (union-of1 index)
+    (union-of1 json-key-lit))))
+
+(def child-dot
+  "Stupid dot syntax"
+  (k/>>
+   kl/dot
+   (k/<|>
+    ;; normal key
+    (k/<$>
+     (partial hash-set)
+     (k/<+> (k/many1 k/alpha-num)))
+    ;; dot wildcard
+    wildcard
+    ;; double-dot wildcard
+    (k/<$>
+     (constantly '*)
+     (k/look-ahead
+      (k/>> kl/dot
+            (k/many1 k/alpha-num)))))))
+
+
+(def json-path
+  (k/>> root
+        (k/many (k/<|>
+                 child-normal
+                 child-dot))))
+
+(s/def ::json-path
+  (s/every (s/or :keyset ::keyset
+                 :wildcard ::wildcard
+                 :range ::range)))
+
+(s/fdef parse
+  :args (s/cat :path string?)
+  :ret ::json-path)
+
+(defn parse
+  "Given a JSON-path, parse it into data"
+  [path]
+  (:value (k/parse json-path
+                   path)))

--- a/src/main/com/yetanalytics/datasim/json/zip.clj
+++ b/src/main/com/yetanalytics/datasim/json/zip.clj
@@ -1,0 +1,218 @@
+(ns com.yetanalytics.datasim.json.zip
+  (:require [clojure.zip :as z]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as sgen]
+            [com.yetanalytics.datasim.json :as json]))
+
+(s/def :com.yetanalytics.datasim.json.zip.loc.ppath/l
+  (s/nilable
+   (s/every ::json/any)))
+
+(s/def :com.yetanalytics.datasim.json.zip.loc.ppath/r
+  (s/nilable
+   (s/every ::json/any)))
+
+(s/def :com.yetanalytics.datasim.json.zip.loc.ppath/pnodes
+  (s/nilable
+   (s/every ::json/any)))
+
+(s/def :com.yetanalytics.datasim.json.zip.loc/ppath
+  (s/nilable
+   (s/keys :req-un
+           [:com.yetanalytics.datasim.json.zip.loc.ppath/l
+            :com.yetanalytics.datasim.json.zip.loc.ppath/r
+            :com.yetanalytics.datasim.json.zip.loc.ppath/pnodes
+            :com.yetanalytics.datasim.json.zip.loc/ppath])))
+
+(declare json-zip)
+
+(s/def ::loc
+  (s/with-gen (s/tuple ::json/any
+                       :com.yetanalytics.datasim.json.zip.loc/ppath)
+    (fn []
+      (sgen/bind
+       (s/gen ::json/any)
+       (fn [any-json]
+         (sgen/elements
+          (take-while (complement z/end?)
+                      (iterate z/next
+                               (json-zip any-json)))))))))
+
+
+(s/fdef json-zip
+  :args (s/cat :root ::json/any)
+  :ret ::loc
+  :fn (fn [{{root :root} :args
+            [node _] :ret}]
+        (= root node)))
+
+(defn json-zip
+  "Produce a zipper for the JSON"
+  [root]
+  (z/zipper
+   coll?
+   seq
+   (fn make-node
+     [node kids]
+     (if-let [empty-coll (empty node)]
+       (into empty-coll
+             kids)
+       ;; if clojure.core/empty doesn't work, check for map entry
+       (if (map-entry? node)
+         (if (= 2 (count kids))
+           (let [[k v] kids]
+             (clojure.lang.MapEntry. k v))
+           (throw (ex-info "Can only have two children in a MapEntry"
+                           {:type ::map-entry-constraint
+                            :node node
+                            :children kids})))
+         (throw (ex-info (format "Don't know how to make %s node" (type node))
+                         {:type ::unknown-collection
+                          :node node
+                          :node-type (type node)
+                          :children kids})))))
+   root))
+
+(s/fdef internal?
+  :args (s/cat :loc ::loc)
+  :ret boolean?)
+
+(defn internal?
+  "Is a location internal, ie a map entry or key"
+  [loc]
+  (let [node (z/node loc)]
+    (or (map-entry? node)
+        ;; key position
+        (and (string? node)
+             (zero? (count (z/lefts loc)))
+             (some-> loc z/up z/node map-entry?))
+        false)))
+
+(s/def ::key
+  (s/or :index (s/int-in 0 Integer/MAX_VALUE)
+        :key (s/or :string string?
+                   :keyword keyword?)))
+
+(s/fdef el-key
+  :args (s/cat :loc ::loc)
+  :ret (s/nilable
+        ::key))
+
+(defn el-key
+  [loc]
+  (when-not (internal? loc)
+    (when-let [p (peek (z/path loc))]
+      (cond
+        (map-entry? p)
+        (key p)
+
+        (vector? p)
+        (count (z/lefts loc))))))
+
+(s/def ::key-path
+  (s/every ::key))
+
+(s/fdef k-path
+  :args (s/cat :loc ::loc)
+  :ret (s/nilable
+        ::key-path))
+
+(defn k-path
+  [loc]
+  (into []
+        (reverse
+         (keep el-key
+               (take-while some?
+                           (iterate z/up loc))))))
+
+;; given a root and a key-path, can we return a loc at that path?
+;; this would make up some for the inefficiency of having to walk everything
+;; when there is a known path?
+
+(s/fdef get-child
+  :args (s/cat :loc ::loc
+               :k ::key)
+  :ret (s/nilable ::loc))
+
+(defn get-child
+  "Returns the child of loc at k or nil if key not present.
+  Will skip map-entries entirely, like clojure.core/get"
+  [loc k]
+  (when (and loc
+             (z/branch? loc)
+             (not (internal? loc)))
+    (let [node (z/node loc)]
+      (when-let [[fk fv :as found] (find node k)]
+        (let [child-locs (iterate z/right
+                                  (z/down loc))]
+          (if (map? node)
+            ;; if the node is a map, we want to skip the map entries
+            (-> (some
+                 (fn [cl]
+                   (when (= found (z/node cl))
+                     cl))
+                 child-locs)
+                z/down
+                z/right)
+            (nth child-locs fk)))))))
+
+(s/fdef get-child-in
+  :args (s/cat :loc (s/nilable ::loc)
+               :key-path ::key-path)
+  :ret (s/nilable ::loc))
+
+
+(defn get-child-in
+  "Like clojure.core/get-in, but for zipper structures."
+  [loc key-path]
+  (reduce get-child loc key-path))
+
+(s/fdef loc-in
+  :args (s/cat :root ::json/any
+               :key-path ::key-path)
+  :ret (s/nilable ::loc))
+
+(defn loc-in
+  "Convenience, like get-child-in, but it takes root and returns a loc or nil."
+  [root key-path]
+  (-> root json-zip (get-child-in key-path)))
+
+(s/def ::path-map
+  (s/map-of
+   ::key-path
+   ::json/any))
+
+(s/fdef json-locs
+  :args (s/cat :json ::json/any)
+  :ret (s/every ::loc)
+  :fn (fn [{locs :ret}]
+        (every? (complement internal?) locs)))
+
+(defn json-locs
+  [json]
+  (->> json
+       json-zip
+       (iterate z/next)
+       (take-while (complement z/end?))
+       ;; don't look at map entries/keys
+       (remove internal?)))
+
+(s/fdef json->path-map
+  :args (s/cat :json ::json/any)
+  :ret ::path-map)
+
+(defn json->path-map
+  "given some json, return a map of full paths to values"
+  [json]
+  (into {}
+        (map (fn [loc]
+               [(k-path loc) (z/node loc)])
+             (json-locs json))))
+
+(s/fdef path-map->json
+  :args (s/cat :path-map ::path-map)
+  :ret ::json/any)
+
+(defn path-map->json
+  [path-map]
+  (get path-map []))

--- a/src/main/com/yetanalytics/datasim/xapi/path.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/path.clj
@@ -1,0 +1,220 @@
+(ns com.yetanalytics.datasim.xapi.path
+  "Given a path into an xAPI structure, return a spec from xapi-schema"
+  (:require [com.yetanalytics.datasim.json :as json]
+            [clojure.spec.alpha :as s]
+            [xapi-schema.spec :as xs]))
+
+(s/def :spec-map.map-spec/keys
+  qualified-keyword?)
+
+(s/def :spec-map.map-spec/vals
+  qualified-keyword?)
+
+(s/def :spec-map/map-spec
+  (s/keys :req-un [:spec-map.map-spec/keys
+                   :spec-map.map-spec/vals]))
+
+(s/def ::spec-map
+  (s/map-of
+   qualified-keyword?
+   (s/or :ns string?
+         :keyword qualified-keyword?
+         :fn fn?
+         :vector vector?
+         :map :spec-map/map-spec)))
+
+(def spec-map
+  {::xs/statement "statement"
+
+   :statement/actor ::xs/actor
+   :statement/verb ::xs/verb
+   :statement/object
+   (fn [{:strs [objectType] :as object}]
+     (case objectType
+       "StatementRef" ::xs/statement-ref
+       "SubStatement" ::xs/sub-statement
+       "Agent"        ::xs/agent
+       "Group"        ::xs/group
+       ::xs/activity))
+   :statement/result ::xs/result
+   :statement/context ::xs/context
+   :statement/authority ::xs/actor
+   :statement/attachments ::xs/attachments
+
+   ::xs/attachments
+   [::xs/attachment]
+
+   ::xs/attachment
+   "attachment"
+
+   :attachment/display ::xs/language-map
+   :attachment/description ::xs/language-map
+   ::xs/actor
+   (fn [{:strs [objectType] :as actor}]
+     (if (= "Group" objectType)
+       ::xs/group
+       ::xs/agent))
+
+   ::xs/agent
+   "agent"
+
+   :agent/account ::xs/account
+
+   ::xs/group "group"
+
+   :group/account ::xs/account
+   :group/member [::xs/agent]
+
+   ::xs/account "account"
+
+   ::xs/verb "verb"
+   :verb/display ::xs/language-map
+
+   ::xs/statement-ref "statement-ref"
+
+   ::xs/sub-statement "sub-statement"
+
+   :sub-statement/actor ::xs/actor
+   :sub-statement/verb ::xs/verb
+   :sub-statement/result ::xs/result
+   :sub-statement/context ::xs/context
+   :sub-statement/attachments ::xs/attachments
+
+   :sub-statement/object
+   (fn [{:strs [objectType] :as object}]
+     (case objectType
+       "StatementRef" ::xs/statement-ref
+       "Agent"        ::xs/agent
+       "Group"        ::xs/group
+       ::xs/activity))
+
+   ::xs/activity "activity"
+
+   :activity/definition "definition"
+
+   :definition/name ::xs/language-map
+   :definition/description ::xs/language-map
+   :definition/choices ::xs/interaction-components
+   :definition/scale ::xs/interaction-components
+   :definition/source ::xs/interaction-components
+   :definition/target ::xs/interaction-components
+   :definition/steps ::xs/interaction-components
+   :definition/extensions ::xs/extensions
+
+   :definition/correctResponsesPattern [string?]
+
+   ::xs/interaction-components
+   [::xs/interaction-component]
+
+   ::xs/interaction-component "interaction-component"
+
+   :interaction-component/description ::xs/language-map
+
+   ::xs/result "result"
+
+   :result/extensions ::xs/extensions
+
+   :result/score "score"
+
+   ::xs/context "context"
+
+   :context/instructor ::xs/actor
+   :context/team ::xs/group
+   :context/contextActivities ::xs/context-activities
+   :context/statement ::xs/statement-ref
+   :context/extensions ::xs/extensions
+
+   ::xs/context-activities "contextActivities"
+
+   :contextActivities/parent ::xs/context-activities-array
+   :contextActivities/grouping ::xs/context-activities-array
+   :contextActivities/category ::xs/context-activities-array
+   :contextActivities/other ::xs/context-activities-array
+
+   ::xs/context-activities-array
+   [::xs/activity]
+
+   ::xs/language-map {:keys ::xs/language-tag
+                      :vals ::xs/language-map-text}
+   ::xs/extensions {:keys ::xs/iri
+                    :vals ::json/any}
+
+
+   })
+
+(comment
+  (s/valid? ::spec-map spec-map)
+
+
+  )
+
+(defn path->spec
+  "Given a root spec and a path into it, return the spec for
+  that path or nil if it is not possible. Accepts hint data to dispatch
+  multi-specs and the like"
+  ([spec path]
+   (path->spec spec path nil))
+  ([spec path hint-data]
+   (if (empty? path)
+     (do
+       (assert (or (s/get-spec spec)
+                   (fn? spec)
+                   (s/spec? spec)) "Must return a valid, registered spec or a function or a spec literal")
+       spec)
+     (if-let [spec-entry (get spec-map spec)]
+       (let [p-key (first path)]
+         (cond
+           ;; direct ref to another spec, these should be traversed silently
+           (keyword? spec-entry)
+           (recur
+            spec-entry
+            path
+            hint-data)
+
+           ;; an ns name, which gets used to speculatively form a keyword
+           (string? spec-entry)
+           (let [spec-ns spec-entry]
+             (assert (string? p-key) "Path key for a map must be a string")
+             (recur
+              (keyword spec-ns p-key)
+              (rest path)
+              (get hint-data p-key)))
+
+           ;; A vector just specifies that there is a homogenous array
+           (vector? spec-entry)
+           (let [[element-spec] spec-entry]
+             (assert (number? p-key) "Path key for array must be a number")
+             (recur
+              element-spec
+              (rest path)
+              (get hint-data p-key)))
+
+           ;; inference by dispatch function, must have data present or it uses
+           ;; defaults
+           (fn? spec-entry)
+           (let [inferred-spec (spec-entry hint-data)]
+             (recur
+              inferred-spec
+              path
+              hint-data))
+           ;; arbitrary maps
+           (map? spec-entry)
+           (let [{keys-spec :keys
+                  vals-spec :vals} spec-entry]
+             (assert (string? p-key) "Path key for arbitrary map must be a string")
+             (if (s/valid? keys-spec p-key)
+               (if (= vals-spec ::json/any)
+                 ;; don't loop, any path under any-json is any-json
+                 ::json/any
+                 (recur
+                  vals-spec
+                  (rest path)
+                  (get hint-data p-key)))
+               (throw (ex-info "invalid key for string map"
+                               {:type ::invalid-arbitrary-key
+                                :key p-key
+                                :spec spec
+                                :keys-spec keys-spec}))))))
+       (throw (ex-info "No spec in map"
+                       {:type ::no-spec-in-map
+                        :spec spec}))))))

--- a/src/test/com/yetanalytics/datasim/json/path_test.clj
+++ b/src/test/com/yetanalytics/datasim/json/path_test.clj
@@ -1,0 +1,24 @@
+(ns com.yetanalytics.datasim.json.path-test
+  (:require [clojure.test :refer :all]
+            [com.yetanalytics.datasim.json.path :refer :all]
+            [blancas.kern.core :as k]))
+
+(deftest parse-test
+  (are [path v] (= v
+                   (parse path))
+    "$.store.book[*].author" [#{"store"} #{"book"} '* #{"author"}]
+    "$..author"              ['* #{"author"}]
+    "$.store.*"              [#{"store"} '*]
+    "$.store..price"         [#{"store"} '* #{"price"}]
+    "$..book[2]"             ['* #{"book"} #{2}]
+    "$..book[-1:]"           ['* #{"book"} (->RangeSpec -1 9223372036854775807 1)]
+    "$..book[0,1]"           ['* #{"book"} #{0 1}]
+    "$..book[:2]"            ['* #{"book"} (->RangeSpec 0 2 1)]
+    "$..*"                   '[* *]
+    ;; selections from cmi5
+    "$.context.contextActivities.grouping[*]"
+    [#{"context"} #{"contextActivities"} #{"grouping"} '*]
+
+    "$.context.extensions['https://w3id.org/xapi/cmi5/context/extensions/sessionid']"
+    [#{"context"} #{"extensions"} #{"https://w3id.org/xapi/cmi5/context/extensions/sessionid"}]
+    ))

--- a/src/test/com/yetanalytics/datasim/json/zip_test.clj
+++ b/src/test/com/yetanalytics/datasim/json/zip_test.clj
@@ -1,0 +1,44 @@
+(ns com.yetanalytics.datasim.json.zip-test
+  (:require [clojure.test :refer :all]
+            [com.yetanalytics.datasim.json :as json]
+            [com.yetanalytics.datasim.json.zip :refer :all]
+            [clojure.zip :as z]
+            [clojure.test.check :as tc]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.test.check.properties :as prop]
+            [clojure.test.check.clojure-test :refer :all]))
+
+(deftest zip-functions-test
+  (let [results (stest/check
+                 `#{json-zip
+                    internal?
+                    el-key
+                    k-path
+                    get-child
+                    get-child-in
+                    loc-in
+                    json-locs
+                    json->path-map
+                    path-map->json
+                    })
+        {:keys [total
+                check-passed]} (stest/summarize-results results)]
+    (is (= total check-passed))))
+
+(defspec k-path-is-valid-for-get-in
+  (prop/for-all
+   [json (s/gen ::json/any)]
+   (let [locs (->> json
+                   json-zip
+                   (iterate z/next)
+                   (take-while (complement z/end?))
+                   ;; don't look at map entries
+                   (remove internal?))]
+     (every?
+      (fn [loc]
+        (let [key-path (k-path loc)]
+          (= (z/node loc)
+             (get-in json key-path)
+             (z/node (loc-in json key-path)))))
+      locs))))

--- a/src/test/com/yetanalytics/datasim/xapi/path_test.clj
+++ b/src/test/com/yetanalytics/datasim/xapi/path_test.clj
@@ -1,0 +1,36 @@
+(ns com.yetanalytics.datasim.xapi.path-test
+  (:require [clojure.test :refer :all]
+            [com.yetanalytics.datasim.xapi.path :refer :all]
+            [xapi-schema.spec :as xs]
+            [clojure.spec.alpha :as s]
+            [com.yetanalytics.datasim.json.zip :as pzip]
+            [clojure.java.io :as io]
+            [clojure.data.json :as json]))
+
+(deftest spec-map-test
+  (is (s/valid? :com.yetanalytics.datasim.xapi.path/spec-map spec-map)))
+
+(def long-statement
+  (with-open
+    [r (io/reader (io/resource "xapi/statements/long.json"))]
+    (json/read r)))
+
+
+(deftest path->spec-test
+  (testing "works for lots of paths"
+    ;; Explode a statement using a helper from our zipperoo to get a bunch of
+    ;; paths and leaf values
+    (is (every?
+         (fn [[path v]]
+           (let [spec (path->spec ::xs/statement path long-statement)]
+             (and spec
+                  (s/valid? spec v))))
+         (pzip/json->path-map long-statement))))
+
+  (testing "works for arbitrary and relative paths"
+    (is (= ::xs/language-map-text
+           (path->spec ::xs/activity ["definition" "name" "en-US"]))))
+  (testing "can return functions for use as specs"
+    (is (= string?
+           (path->spec ::xs/statement
+                       ["object" "definition" "correctResponsesPattern" 0])))))


### PR DESCRIPTION
Integrate my lib work from yetanalytics/pathetic, which includes:

- A general JSON zipper
- A simple JSONPath parser
- Walkable spec bindings for `xapi-schema` specs