### PR TITLE
clj version should be locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The simulation specification is a single object containing of all of the above. 
 
 Java (JDK 8+, OpenJDK or Oracle)
 
-Clojure (1.10.1+)
+[Clojure CLI (1.10.2+)](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools)
 
 ### Deployment Models
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["resources" "src/main"]
- :deps {org.clojure/clojure {:mvn/version "RELEASE"}
+ :deps {org.clojure/clojure {:mvn/version "1.10.2"}
         org.clojure/core.async {:mvn/version "1.3.610"}
         org.clojure/core.memoize {:mvn/version "0.8.2"}
         com.yetanalytics/xapi-schema


### PR DESCRIPTION
For now, `1.10.2`