### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,12 @@ jobs:
 
     - name: Build Bundle
       run: make bundle
-    
+
+    - name: Compress Bundle
+      run: | # Need to cd so that the zip file doesn't contain the parent dirs
+        cd target/bundle
+        zip -r ../../datasim.zip ./
+
     - name: Archive Bundle (Branch Pushes)
       if: ${{ github.ref_type == 'branch' }}
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,5 @@ jobs:
       if: ${{ github.ref_type == 'branch' }}
       uses: actions/upload-artifact@v2
       with:
-        name: datasim-artifact${{ github.sha }}
+        name: datasim-artifact-${{ github.sha }}
         path: datasim.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
-    needs: build_jre
+
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: CD
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    needs: build_jre
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+    
+    - name: Setup CI environment
+      uses: yetanalytics/actions/setup-env@v0.0.2
+
+    - name: Build Bundle
+      run: make bundle
+    
+    - name: Archive Bundle (Branch Pushes)
+      if: ${{ github.ref_type == 'branch' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: datasim-artifact${{ github.sha }}
+        path: datasim.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,11 @@ jobs:
   validate-template:
     runs-on: ubuntu-latest
 
-    env:
-      AWS_ACCESS_KEY_ID: DummyKey
-      AWS_SECRET_ACCESS_KEY: DummySecret
-      AWS_REGION: us-east-1
+    # These permissions are needed by configure-aws-credentials in order
+    # to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write # required to use OIDC authentication
+      contents: read  # required to checkout the code from the repo
 
     steps:
     - name: Checkout Repository
@@ -34,6 +35,13 @@ jobs:
     
     - name: Setup CI environment
       uses: yetanalytics/actions/setup-env@v0.0.2
-    
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ secrets.CF_VALIDATE_TEMPLATE_ROLE_ARN }}
+        role-duration-seconds: 600
+        aws-region: us-east-1
+
     - name: Run Makefile Target validate-template
       run: make validate-template

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v1
       with:
         role-to-assume: ${{ secrets.CF_VALIDATE_TEMPLATE_ROLE_ARN }}
-        role-duration-seconds: 600
+        role-duration-seconds: 900 # 15 min; minimal duration possible
         aws-region: us-east-1
 
     - name: Run Makefile Target validate-template

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        target: [test-unit, test-cli]
+    
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+    
+    - name: Setup CI environment
+      uses: yetanalytics/actions/setup-env@v0.0.2
+    
+    - name: Run Makefile Target ${{ matrix.target }}
+      run: make ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,25 @@ jobs:
     strategy:
       matrix:
         target: [test-unit, test-cli]
-    
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Setup CI environment
+      uses: yetanalytics/actions/setup-env@v0.0.2
+
+    - name: Run Makefile Target ${{ matrix.target }}
+      run: make ${{ matrix.target }}
+
+  validate-template:
+    runs-on: ubuntu-latest
+
+    env:
+      AWS_ACCESS_KEY_ID: DummyKey
+      AWS_SECRET_ACCESS_KEY: DummySecret
+      AWS_REGION: us-east-1
+
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
@@ -17,5 +35,5 @@ jobs:
     - name: Setup CI environment
       uses: yetanalytics/actions/setup-env@v0.0.2
     
-    - name: Run Makefile Target ${{ matrix.target }}
-      run: make ${{ matrix.target }}
+    - name: Run Makefile Target validate-template
+      run: make validate-template


### PR DESCRIPTION
This PR implements the pre-existing CodeBuild CI actions in GitHub Actions. (So no extra NVD scanning, linting, Clojars deployment, etc.)
- Perform the `test-cli` and `test-unit` tests
- Build the DS bundle and publish it as an artifact
- Perform the `validate-templates` check (using OIDC to provide AWS credentials as so: https://benoitboure.com/securely-access-your-aws-resources-from-github-actions)