### PR TITLE
[DS-119] NVD Scanning and Dep Updating

### DIFF
--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -1,8 +1,8 @@
 name: Periodic NVD Scan
 
-on: push
-  # schedule:
-    # - cron: '0 8 * * *' # Every day at 8:00 AM
+on:
+  schedule:
+    - cron: '0 8 * * *' # Every day at 8:00 AM
 
 jobs:
   nvd-scan:

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -6,9 +6,24 @@ on:
     - cron: '* * * * *'
 
 jobs:
-  nvd_scan:
+  nvd-scan:
     uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.3
     with:
       nvd-clojure-version: '2.0.0'
       classpath-command: 'clojure -Spath -A:cli:server'
       # nvd-config-filename: '.nvd/config.json'
+
+  notify-slack:
+    needs: [nvd-scan]
+    if: ${{ always() && (needs.nvd-scan.result == 'failure') }}
+    steps:
+    - name: Notify Slack DATASIM NVD Scan Reporter 
+      id: slack
+      uses: slackapi/slack-github-action@v1.18.0
+      with:
+        payload: |
+          {
+            "run_id": ${{ github.run_id }}
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -18,7 +18,6 @@ jobs:
     if: ${{ always() && (needs.nvd-scan.result == 'failure') }}
     steps:
     - name: Notify Slack DATASIM NVD Scan Reporter 
-      id: slack
       uses: slackapi/slack-github-action@v1.18.0
       with:
         payload: |

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         payload: |
           {
-            "run_id": ${{ github.run_id }}
+            "run_link": "https://github.com/yetanalytics/datasim/actions/runs/${{ github.run_id }}"
           }
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -1,0 +1,14 @@
+name: Periodic NVD Scan
+
+on:
+  schedule:
+    # - cron: '0 8 * * *' # Every day at 8:00 AM
+    - cron: '* * * * *'
+
+jobs:
+  nvd_scan:
+    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.3
+    with:
+      nvd-clojure-version: '2.0.0'
+      classpath-command: 'clojure -Spath -A:cli:server'
+      # nvd-config-filename: '.nvd/config.json'

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -10,7 +10,7 @@ jobs:
     with:
       nvd-clojure-version: '2.0.0'
       classpath-command: 'clojure -Spath -A:cli:server'
-      # nvd-config-filename: '.nvd/config.json'
+      nvd-config-filename: '.nvd/config.json'
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -13,6 +13,7 @@ jobs:
       # nvd-config-filename: '.nvd/config.json'
 
   notify-slack:
+    runs-on: ubuntu-latest
     needs: [nvd-scan]
     if: ${{ always() && (needs.nvd-scan.result == 'failure') }}
     steps:

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -3,7 +3,7 @@ name: Periodic NVD Scan
 on:
   schedule:
     # - cron: '0 8 * * *' # Every day at 8:00 AM
-    - cron: '* * * * *'
+    - cron: '0,10,20,30,40,50 * * * *'
 
 jobs:
   nvd-scan:

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -2,7 +2,7 @@ name: Periodic NVD Scan
 
 on:
   schedule:
-    - cron: '0 8 * * *' # Every day at 8:00 AM
+    - cron: '0 8 * * 1-5' # Every weekday at 8:00 AM
 
 jobs:
   nvd-scan:

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -1,9 +1,8 @@
 name: Periodic NVD Scan
 
-on:
-  schedule:
+on: push
+  # schedule:
     # - cron: '0 8 * * *' # Every day at 8:00 AM
-    - cron: '0,10,20,30,40,50 * * * *'
 
 jobs:
   nvd-scan:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,8 @@ jobs:
     uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.3
     with:
       nvd-clojure-version: '2.0.0'
-      classpath-command: 'clojure -Spath -A:cli:server:onyx'
+      # onyx dep is outdated and abandoned so don't bother scanning
+      classpath-command: 'clojure -Spath -A:cli:server'
       nvd-config-filename: '.nvd/config.json'
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,13 @@ name: CI
 on: push
 
 jobs:
+  nvd-scan:
+    uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.3
+    with:
+      nvd-clojure-version: '2.0.0'
+      classpath-command: 'clojure -Spath -A:cli:server:onyx'
+      nvd-config-filename: '.nvd/config.json'
+
   test:
     runs-on: ubuntu-latest
 

--- a/.nvd/config.json
+++ b/.nvd/config.json
@@ -1,0 +1,3 @@
+{
+  "nvd": {"suppression-file": ".nvd/suppression.xml"}
+}

--- a/.nvd/suppression.xml
+++ b/.nvd/suppression.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+   <suppress>
+      <notes><![CDATA[
+      file name: core.async-1.5.648.jar
+      ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.clojure/core\.async@.*$</packageUrl>
+      <cpe>cpe:/a:async_project:async</cpe>
+   </suppress>
+</suppressions>

--- a/deps.edn
+++ b/deps.edn
@@ -10,6 +10,8 @@
          :exclusions [org.clojure/clojurescript
                       com.yetanalytics./xapi-schema]}
         clojure.java-time/clojure.java-time {:mvn/version "0.3.2"}
+        ;; org.threeten/threeten-extra {:mvn/version "1.4"}
+        org.apache.jena/jena-iri {:mvn/version "3.13.1"}
         ;; JSON Path Parser built with
         org.blancas/kern {:mvn/version "1.1.0"}
         org.clojure/test.check {:mvn/version "1.0.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -16,8 +16,22 @@
         org.blancas/kern {:mvn/version "1.1.0"}
         org.clojure/test.check {:mvn/version "1.0.0"}
         org.clojure/math.combinatorics {:mvn/version "0.1.6"}
-        cheshire/cheshire {:mvn/version "5.10.0"}
-        http-kit/http-kit {:mvn/version "2.5.0"}}
+        http-kit/http-kit {:mvn/version "2.5.0"}
+        ;; Include Jackson to avoid CVE
+        cheshire/cheshire
+        {:mvn/version "5.10.2"
+         :exclusions [com.fasterxml.jackson.core/jackson-core
+                      com.fasterxml.jackson.dataformat/jackson-dataformat-smile
+                      com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
+                      com.fasterxml.jackson.core/jackson-databind]}
+        com.fasterxml.jackson.core/jackson-core
+        {:mvn/version "2.13.2"}
+        com.fasterxml.jackson.dataformat/jackson-dataformat-smile
+        {:mvn/version "2.13.2"}
+        com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
+        {:mvn/version "2.13.2"}
+        com.fasterxml.jackson.core/jackson-databind
+        {:mvn/version "2.13.2.1"}}
  :aliases
  {:cli {:extra-paths ["src/cli"]
         :extra-deps {org.clojure/tools.cli {:git/url "https://github.com/clojure/tools.cli"

--- a/deps.edn
+++ b/deps.edn
@@ -51,7 +51,7 @@
   {:extra-paths ["src/server"]
    :extra-deps  {io.pedestal/pedestal.service
                  {:mvn/version "0.5.10"}
-                 io.pedestal/pedestal.immutant
+                 io.pedestal/pedestal.jetty
                  {:mvn/version "0.5.10"}
                  org.slf4j/slf4j-simple
                  {:mvn/version "1.7.28"}

--- a/deps.edn
+++ b/deps.edn
@@ -59,7 +59,7 @@
                  clj-http/clj-http
                  {:mvn/version "3.10.0"}
                  buddy/buddy-auth
-                 {:mvn/version "2.2.0"
+                 {:mvn/version "3.0.323"
                   :exclusions [cheshire/cheshire]}
                  environ/environ
                  {:mvn/version "1.1.0"}}

--- a/deps.edn
+++ b/deps.edn
@@ -51,9 +51,9 @@
   :server
   {:extra-paths ["src/server"]
    :extra-deps  {io.pedestal/pedestal.service
-                 {:mvn/version "0.5.7"}
+                 {:mvn/version "0.5.10"}
                  io.pedestal/pedestal.immutant
-                 {:mvn/version "0.5.7"}
+                 {:mvn/version "0.5.10"}
                  org.slf4j/slf4j-simple
                  {:mvn/version "1.7.28"}
                  clj-http/clj-http

--- a/deps.edn
+++ b/deps.edn
@@ -56,7 +56,7 @@
                  org.slf4j/slf4j-simple
                  {:mvn/version "1.7.28"}
                  clj-http/clj-http
-                 {:mvn/version "3.10.0"}
+                 {:mvn/version "3.12.3"}
                  buddy/buddy-auth
                  {:mvn/version "3.0.323"
                   :exclusions [cheshire/cheshire]}

--- a/deps.edn
+++ b/deps.edn
@@ -10,8 +10,6 @@
          :exclusions [org.clojure/clojurescript
                       com.yetanalytics./xapi-schema]}
         clojure.java-time/clojure.java-time {:mvn/version "0.3.2"}
-        ;; org.threeten/threeten-extra {:mvn/version "1.4"}
-        org.apache.jena/jena-iri {:mvn/version "3.13.1"}
         ;; JSON Path Parser built with
         org.blancas/kern {:mvn/version "1.1.0"}
         org.clojure/test.check {:mvn/version "1.0.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -10,8 +10,7 @@
          :exclusions [org.clojure/clojurescript
                       com.yetanalytics./xapi-schema]}
         clojure.java-time/clojure.java-time {:mvn/version "0.3.2"}
-        ;; org.threeten/threeten-extra {:mvn/version "1.4"}
-        org.apache.jena/jena-iri {:mvn/version "3.13.1"}
+        org.apache.jena/jena-iri {:mvn/version "4.4.0"}
         ;; JSON Path Parser built with
         org.blancas/kern {:mvn/version "1.1.0"}
         org.clojure/test.check {:mvn/version "1.0.0"}

--- a/src/server/com/yetanalytics/datasim/server.clj
+++ b/src/server/com/yetanalytics/datasim/server.clj
@@ -257,10 +257,10 @@
   []
   (http/create-server
    {::http/routes          routes
-    ::http/type            :immutant
+    ::http/type            :jetty
     ::http/allowed-origins ["https://yetanalytics.github.io"
                             "http://localhost:9091"]
-    ::http/host "0.0.0.0"
+    ::http/host            "0.0.0.0"
     ::http/port            9090
     ::http/join?           false}))
 


### PR DESCRIPTION
Add on-push and periodic NVD scanning and update the following deps:
- cheshire to 5.10.2
- jackson to 2.13.2
- jena-iri to 4.4.0
- clj-http to 3.12.3
- pedestal to 0.5.10
- buddy-auth to 3.0.323

Also switch the webserver from Immutant to Jetty due to the former having a number of CVEs.

Aliases scanned: `:clj` and `:server`. `:onyx` is not scanned due to the Onyx lib being effectively abandoned and riddled with CVEs while not being a client priority at the moment.

Periodic NVD scans occur every weekend at 8 AM; upon failure they will notify the "DATASIM NVD Scan Reporter" Slack workflow.