### PR TITLE
Update Jena IRI dep

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,7 @@
          :exclusions [org.clojure/clojurescript
                       com.yetanalytics./xapi-schema]}
         clojure.java-time/clojure.java-time {:mvn/version "0.3.2"}
-        org.apache.jena/jena-iri {:mvn/version "4.4.0"}
+        org.apache.jena/jena-iri {:mvn/version "4.5.0"}
         ;; JSON Path Parser built with
         org.blancas/kern {:mvn/version "1.1.0"}
         org.clojure/test.check {:mvn/version "1.0.0"}


### PR DESCRIPTION
Jena 4.4.0 contains a CVE (CVE-2022-28890) so we update the dep to Jena 4.5.0.

**Question:** Is jena-iri even a necessary dependency in the first place, or can we substitute it with simpler methods?