### PR TITLE
DS-123 add env vars for API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,19 +188,17 @@ By default the server starts at http://localhost:9090
 
 ##### API Config
 
-There are two main ways you may want to add additional configuration to the API. The first is the Basic Authentication credentials required to call the API endpoints. Currently on startup the application looks for an Environment Variable called "credentials" in the form of "username:password". So if the username were datasim, and the password were datasim it would be "datasim:datasim". You can set this before launching by setting a local env variable on your machine.
+The API is configurable with the following runtime environment variables:
 
-The second is the port and allowed-origins if running from a browser. You can edit **http/allowed-origins** and **http/port** the following object in */src/server/com/yetanalytics/datasim/server.clj* to do so:
+| Variable            | Default                                                | Notes                                                                                                  | Example           |
+|---------------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------|-------------------|
+| CREDENTIALS         | <none>                                                 | Basic Authentication credentials required to call the API endpoints in the form of `username:password` | `datasim:datasim` |
+| API_ROOT_PATH       | <none>                                                 | Root path to prefix API routes. Must begin with a `/`, cannot end with a `/`.                          | `/foo`            |
+| API_HOST            | `0.0.0.0`                                              | Host on which to bind the API server.                                                                  | `localhost`       |
+| API_PORT            | `9090`                                                 | Port on which to bind the API server.                                                                  | `8080`            |
+| API_ALLOWED_ORIGINS | `https://yetanalytics.github.io,http://localhost:9091` | CORS allowed origins for the API server, separated by commas.                                          | `*`               |
 
-    {::http/routes          routes
-     ::http/type            :immutant
-     ::http/allowed-origins ["https://yetanalytics.github.io"
-                         "http://localhost:9091"]
-     ::http/host "0.0.0.0"
-     ::http/port            9090
-     ::http/join?           false}
-
-Currently they are both configured to work with the default settings in the DATASIM-UI project locally.
+Currently defaults are configured to work with the default settings in the DATASIM-UI project locally.
 
 ##### API Endpoints
 

--- a/README.md
+++ b/README.md
@@ -190,13 +190,13 @@ By default the server starts at http://localhost:9090
 
 The API is configurable with the following runtime environment variables:
 
-| Variable            | Default                                                | Notes                                                                                                  | Example           |
-|---------------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------|-------------------|
-| CREDENTIALS         | <none>                                                 | Basic Authentication credentials required to call the API endpoints in the form of `username:password` | `datasim:datasim` |
-| API_ROOT_PATH       | <none>                                                 | Root path to prefix API routes. Must begin with a `/`, cannot end with a `/`.                          | `/foo`            |
-| API_HOST            | `0.0.0.0`                                              | Host on which to bind the API server.                                                                  | `localhost`       |
-| API_PORT            | `9090`                                                 | Port on which to bind the API server.                                                                  | `8080`            |
-| API_ALLOWED_ORIGINS | `https://yetanalytics.github.io,http://localhost:9091` | CORS allowed origins for the API server, separated by commas.                                          | `*`               |
+| Variable            | Default                                                                                          | Notes                                                                                                  | Example           |
+|---------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|-------------------|
+| CREDENTIALS         | <none>                                                                                           | Basic Authentication credentials required to call the API endpoints in the form of `username:password` | `datasim:datasim` |
+| API_ROOT_PATH       | <none>                                                                                           | Root path to prefix API routes. Must begin with a `/`, cannot end with a `/`.                          | `/foo`            |
+| API_HOST            | `0.0.0.0`                                                                                        | Host on which to bind the API server.                                                                  | `localhost`       |
+| API_PORT            | `9090`                                                                                           | Port on which to bind the API server.                                                                  | `8080`            |
+| API_ALLOWED_ORIGINS | <details>`https://yetanalytics.github.io,http://localhost:9091`<summary>(URLs)</summary></details> | CORS allowed origins for the API server, separated by commas.                                          | `*`               |
 
 Currently defaults are configured to work with the default settings in the DATASIM-UI project locally.
 

--- a/src/server/com/yetanalytics/datasim/server.clj
+++ b/src/server/com/yetanalytics/datasim/server.clj
@@ -22,7 +22,8 @@
             [com.yetanalytics.pan.objects.pattern   :as pan-pat]
             [com.yetanalytics.pan.errors            :as errors]
             [clojure.spec.alpha                     :as s]
-            [com.yetanalytics.datasim.util.sequence :as su])
+            [com.yetanalytics.datasim.util.sequence :as su]
+            [clojure.string                         :as str])
   (:import [javax.servlet ServletOutputStream])
   (:gen-class))
 
@@ -240,29 +241,48 @@
 ;; Routes and server configs
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def routes
-  (route/expand-routes
-   #{["/health"
-      :get        health
-      :route-name :datasim.route/health]
-     ["/api/v1/generate"
-      :post (into common-interceptors
-                  [(multipart-params)
-                   generate])]
-     ["/api/v1/download-url"
-      :get  (into common-interceptors
-                  [download-url])]}))
-
 (defn create-server
   []
-  (http/create-server
-   {::http/routes          routes
-    ::http/type            :jetty
-    ::http/allowed-origins ["https://yetanalytics.github.io"
-                            "http://localhost:9091"]
-    ::http/host            "0.0.0.0"
-    ::http/port            9090
-    ::http/join?           false}))
+  (let [root-path       (get env :api-root-path "")
+        _               (when (not-empty root-path)
+                          (when-not (str/starts-with? root-path "/")
+                            (throw (ex-info "API_ROOT_PATH must start with /"
+                                            {:type      ::invalid-root-path
+                                             :root-path root-path})))
+                          (when (str/ends-with? root-path "/")
+                            (throw (ex-info "API_ROOT_PATH must not end with /"
+                                            {:type      ::invalid-root-path
+                                             :root-path root-path}))))
+        host            (get env :api-host
+                             "0.0.0.0")
+        port            (or (some-> env :api-port Long/parseLong)
+                            9090)
+        allowed-origins (if-let [allowed-str (:api-allowed-origins env)]
+                          (str/split allowed-str #",")
+                          ["https://yetanalytics.github.io"
+                           "http://localhost:9091"])]
+    (log/info :msg "Starting DATASIM API..."
+              :root-path root-path
+              :host host
+              :port port
+              :allowed-origins allowed-origins)
+    (http/create-server
+     {::http/routes          (route/expand-routes
+                              #{[(str root-path "/health")
+                                 :get        health
+                                 :route-name :datasim.route/health]
+                                [(str root-path "/api/v1/generate")
+                                 :post (into common-interceptors
+                                             [(multipart-params)
+                                              generate])]
+                                [(str root-path "/api/v1/download-url")
+                                 :get  (into common-interceptors
+                                             [download-url])]})
+      ::http/type            :jetty
+      ::http/allowed-origins allowed-origins
+      ::http/host            host
+      ::http/port            port
+      ::http/join?           false})))
 
 (defn start
   []


### PR DESCRIPTION
[DS-123] API server should have a configurable root prefix, host, port etc.

[DS-123]: https://yet.atlassian.net/browse/DS-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ