### PR TITLE
DS-124 Fix lazy input parsing errors

### DIFF
--- a/dev-resources/alignments/tccc_dev.json
+++ b/dev-resources/alignments/tccc_dev.json
@@ -1201,7 +1201,7 @@
       },
       {
         "component": "https://books.allogy.com/v1/tenant/8/media/600b7164-32a3-41a3-9b4d-da32d22f10e0",
-        "weight": 0
+        "weight": 0.0
       },
       {
         "component": "https://xapinet.org/xapi/tc3/cuf/hemorrhage_control/v1/templates#seeked:soft_self_routed",

--- a/src/main/com/yetanalytics/datasim/input/alignments.clj
+++ b/src/main/com/yetanalytics/datasim/input/alignments.clj
@@ -81,7 +81,7 @@
   (read-key-fn [this k]
     (keyword nil (name k)))
   (read-body-fn [this json-result]
-    (map->Alignments {:alignment-vector json-result}))
+    (map->Alignments {:alignment-vector (into [] json-result)}))
   (write-key-fn [this k]
     (name k))
   (write-body-fn [this]

--- a/src/main/com/yetanalytics/datasim/io.clj
+++ b/src/main/com/yetanalytics/datasim/io.clj
@@ -11,7 +11,8 @@
          (try
            (p/read-body-fn
             record
-            (json/parse-stream r (partial p/read-key-fn record)))
+            (doall ;; Force eager parsing of the entire file
+             (json/parse-stream r (partial p/read-key-fn record))))
            (catch Exception e
              (throw (ex-info "Parse Error"
                              {:type ::parse-error

--- a/src/test/com/yetanalytics/datasim/input_test.clj
+++ b/src/test/com/yetanalytics/datasim/input_test.clj
@@ -39,6 +39,12 @@
     ;; alignments are a vector of maps containing a vector of maps
     #(assoc % :alignment-vector [{:id "notanid" :alignments [{:component "notaniri" :weight "bar"}]}])
 
+    ;; Fails if JSON parsing is lazy
+    "Actor Alignments, Long"
+    :alignments
+    "dev-resources/alignments/tccc_dev.json"
+    #(assoc % :alignment-vector [{:id "notanid" :alignments [{:component "notaniri" :weight "bar"}]}])
+
     "Actor Alignments w/ Overrides"
     :alignments
     "dev-resources/alignments/simple_with_overrides.json"


### PR DESCRIPTION
[DS-124] It looks like the JSON parser is operating lazily on some longer array inputs, for instance the TC3 alignments input.

This PR fixes that by adding a `doall` to the singular parser in the `io` ns, and explicitly pouring the `:alignments-vector` contents into a vector on read (it comes out of the parser as a list).

Also corrects a single `:weight` value in the `dev-resources/alignments/tccc_dev.json` that lacked a `.0` and was being parsed as an int. A future improvement would be to add coercion there.

[DS-124]: https://yet.atlassian.net/browse/DS-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ