### PR TITLE
[DS-124] CLI Error Printing

### DIFF
--- a/src/cli/com/yetanalytics/datasim/main.clj
+++ b/src/cli/com/yetanalytics/datasim/main.clj
@@ -3,7 +3,7 @@
             [clojure.spec.alpha :as s]
             [clojure.core.async :as a]
             [com.yetanalytics.datasim.input :as input]
-            [expound.alpha :as expound]
+            [com.yetanalytics.datasim.util.errors :as errors]
             [com.yetanalytics.datasim.input.parameters :as params]
             [com.yetanalytics.datasim.runtime :as runtime]
             [com.yetanalytics.datasim.sim :as sim]
@@ -152,9 +152,8 @@
                                   (if (= -1 override-seed)
                                     (.nextLong (Random.))
                                     override-seed)))]
-            (if-let [spec-error (input/validate input)]
-              (bail! [(binding [s/*explain-out* expound/printer]
-                        (expound/explain-result-str spec-error))])
+            (if-let [errors (not-empty (input/validate input))]
+              (bail! (errors/map-coll->strs errors))
               (if ?command
                 (case ?command
                   ;; Where the CLI will actually perform generation

--- a/src/main/com/yetanalytics/datasim/input.clj
+++ b/src/main/com/yetanalytics/datasim/input.clj
@@ -221,9 +221,9 @@
   "Validate input using the FromInput protocol. Throw an exception if the input
    isn't valid."
   [input]
-  (if-let [spec-error (p/validate input)]
-    (throw (ex-info (pr-str spec-error)
+  (if-let [errors (not-empty (p/validate input))]
+    (throw (ex-info "Validation Errors"
                     {:type ::invalid-input
                      :input input
-                     :spec-error spec-error}))
+                     :errors errors}))
     input))

--- a/src/main/com/yetanalytics/datasim/input/profile.clj
+++ b/src/main/com/yetanalytics/datasim/input/profile.clj
@@ -30,6 +30,7 @@
     ;; to internal and external Patterns.
     (let [prof-errs (pan/validate-profile this
                                           :syntax? true
+                                          :pattern-rels? true
                                           :result :type-path-string)]
       (errs/type-path-string-m->map-coll id prof-errs)))
 

--- a/src/main/com/yetanalytics/datasim/protocols.clj
+++ b/src/main/com/yetanalytics/datasim/protocols.clj
@@ -5,7 +5,11 @@
 (defprotocol FromInput
   "Things that come from the user and must be validated."
   (validate [this]
-    "Validate the input, which must be read in first. Returns the output of `s/explain-data`"))
+    "Validate the input, which must be read in first. Returns nil if the input
+     is valid, or a vector of error maps each containing:
+       :id - Generated unique ID for error
+       :path - Path of error in input
+       :text - Error message/text"))
 
 (defprotocol JSONRepresentable
   "Things that can be represented as JSON"

--- a/src/main/com/yetanalytics/datasim/util/errors.clj
+++ b/src/main/com/yetanalytics/datasim/util/errors.clj
@@ -64,3 +64,18 @@
                       (assoc emap :id (str "profiles-" idx))))
        vec
        not-empty))
+
+(def bar
+  (apply str (repeat 80 \=)))
+
+(defn map-coll->strs
+  "Form a list of CLI error strings from an error map coll."
+  [map-coll]
+  (for [{:keys [id path text]} map-coll]
+    (format
+     "%s\nINPUT ERROR: %s\n%s\npath: %s\n\n%s"
+     bar
+     id
+     bar
+     (pr-str path)
+     text)))


### PR DESCRIPTION
[DS-124] Expound error printing is broken for ~~profile~~ all errors, throws when invalid.

This PR replaces expound with a function that generates simple error strings for printing in the CLI.

[DS-124]: https://yet.atlassian.net/browse/DS-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ