### PR TITLE
DS-129 Profile/Pattern Generation Selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ With no commands or `--help` it will give you the list of parameters:
     -C, --concurrency CONC    4    The max concurrency of the LRS POST pipeline
     -L, --post-limit LIMIT    999  The total number of statements that will be sent to the LRS before termination. Overrides sim params. Set to -1 for no limit.
     -A, --[no-]async               Async operation. Use --no-async if statements must be sent to server in timestamp order.
+    --gen-profile IRI              Only generate based on primary patterns in the given profile. May be given multiple times to include multiple profiles.
+    --gen-pattern IRI              Only generate based on the given primary pattern. May be given multiple times to include multiple patterns.
     -h, --help                     Show this list.
 
 For a simple run, we will first create the simulation specification by combining the inputs, validating them, and outputting to a simulation input file like so:

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ See [Deployment Models](#deployment-models) for more information about the diffe
 
 The inputs to DATASIM consist of four parts, each represented by JSON. They are as follows:
 
-#### xAPI Profile
+#### xAPI Profile(s)
 
-A valid xAPI Profile is required for DATASIM to generate xAPI Statements. You can learn more about the xAPI Profile Specification [here](https://github.com/adlnet/xapi-profiles). This input can either be a single Profile JSON-LD document or an array of JSON-LD format profiles. At this time all referenced concepts in a Profile must be included in the input. For instance if in "Profile A" I have a Pattern that references a Statement Template found in "Profile B", both Profiles must be included in an array as the Profile input.
+One or more valid xAPI Profiles are required for DATASIM to generate xAPI Statements. You can learn more about the xAPI Profile Specification [here](https://github.com/adlnet/xapi-profiles). This input can either be a single Profile JSON-LD document or an array of JSON-LD format profiles. At this time all referenced concepts in a Profile must be included in the input. For instance if in "Profile A" I have a Pattern that references a Statement Template found in "Profile B", both Profiles must be included in an array as the Profile input.
+
+Note that by default, any patterns with a `primary` property set to `true` in the provided profiles will be used for generation. You can control which profiles these primary patterns are sourced from with the `gen-profiles` option by supplying one or more profile IDs. You can further control which specific primary patterns are used with the `gen-patterns` option by supplying one or more pattern IDs.
 
 #### Personae
 
@@ -131,8 +133,8 @@ With no commands or `--help` it will give you the list of parameters:
     -C, --concurrency CONC    4    The max concurrency of the LRS POST pipeline
     -L, --post-limit LIMIT    999  The total number of statements that will be sent to the LRS before termination. Overrides sim params. Set to -1 for no limit.
     -A, --[no-]async               Async operation. Use --no-async if statements must be sent to server in timestamp order.
-    --gen-profile IRI              Only generate based on primary patterns in the given profile. May be given multiple times to include multiple profiles.
-    --gen-pattern IRI              Only generate based on the given primary pattern. May be given multiple times to include multiple patterns.
+        --gen-profile IRI          Only generate based on primary patterns in the given profile. May be given multiple times to include multiple profiles.
+        --gen-pattern IRI          Only generate based on the given primary pattern. May be given multiple times to include multiple patterns.
     -h, --help                     Show this list.
 
 For a simple run, we will first create the simulation specification by combining the inputs, validating them, and outputting to a simulation input file like so:

--- a/dev-resources/profiles/referential.jsonld
+++ b/dev-resources/profiles/referential.jsonld
@@ -1,0 +1,43 @@
+{
+  "id" : "https://xapinet.org/xapi/yet/referential",
+  "definition" : {
+    "en" : "Test Profile that refers to another"
+  },
+  "@context" : "https://w3id.org/xapi/profiles/context",
+  "prefLabel" : {
+    "en" : "REFERENTIAL xAPI Profile"
+  },
+  "type" : "Profile",
+  "author" : {
+    "url" : "https://www.yetanalytics.com/",
+    "name" : "Yet Analytics",
+    "type" : "Organization"
+  },
+  "conformsTo" : "https://w3id.org/xapi/profiles#1.0",
+  "versions" : [
+    {
+      "id" : "https://xapinet.org/xapi/yet/referential/v0.0.0",
+      "generatedAtTime" : "2022-06-27T20:34:27.823870Z"
+    }
+  ],
+  "patterns" : [
+    {
+      "id": "https://xapinet.org/xapi/yet/referential#completed_session",
+      "type": "Pattern",
+      "primary": true,
+      "inScheme": "https://xapinet.org/xapi/yet/referential/v0.0.0",
+      "prefLabel": {
+        "en": "completed session"
+      },
+      "definition": {
+        "en": "This pattern describes the sequence of statements sent over the an entire course registration."
+      },
+      "sequence": [
+        "https://w3id.org/xapi/tla#launched",
+        "https://w3id.org/xapi/tla#initialized",
+        "https://w3id.org/xapi/tla#completed",
+        "https://w3id.org/xapi/tla#terminated"
+      ]
+    }
+  ]
+}

--- a/src/cli/com/yetanalytics/datasim/main.clj
+++ b/src/cli/com/yetanalytics/datasim/main.clj
@@ -19,6 +19,11 @@
   [opt-map id v]
   (update opt-map id (fnil conj []) v))
 
+(defn- conj-param-input
+  "Add a parameter named by id."
+  [opt-map id v]
+  (update-in opt-map [:parameters id] (fnil conj []) v))
+
 (defn cli-options
   "Generate CLI options, skipping validation if `validate?` is false"
   [validate?]
@@ -102,6 +107,12 @@
    ["-A" "--[no-]async" "Async operation. Use --no-async if statements must be sent to server in timestamp order."
     :id :async
     :default true]
+   [nil "--gen-profile IRI" "Only generate based on primary patterns in the given profile. May be given multiple times to include multiple profiles."
+    :id :gen-profiles
+    :assoc-fn conj-param-input]
+   [nil "--gen-pattern IRI" "Only generate based on the given primary pattern. May be given multiple times to include multiple patterns."
+    :id :gen-patterns
+    :assoc-fn conj-param-input]
 
    ["-h" "--help"]])
 

--- a/src/main/com/yetanalytics/datasim/input/parameters.clj
+++ b/src/main/com/yetanalytics/datasim/input/parameters.clj
@@ -3,6 +3,8 @@
   (:require [clojure.spec.alpha :as s]
             [com.yetanalytics.datasim.protocols :as p]
             [xapi-schema.spec :as xs]
+            [com.yetanalytics.pan.objects.profile :as prof]
+            [com.yetanalytics.pan.objects.pattern :as pat]
             [java-time :as t]
             [com.yetanalytics.datasim.util.errors :as errs])
   (:import [java.time.zone ZoneRulesException]
@@ -44,6 +46,14 @@
 (s/def ::max
   pos-int?)
 
+;; Restrict Generation to these profile IDs
+(s/def ::gen-profiles
+  (s/every ::prof/id))
+
+;; Restrict Generation to these pattern IDs
+(s/def ::gen-patterns
+  (s/every ::pat/id))
+
 (s/def ::parameters
   (s/and
    (s/keys :req-un [::start
@@ -51,7 +61,9 @@
                     ::seed]
            :opt-un [::end
                     ::from
-                    ::max])
+                    ::max
+                    ::gen-profiles
+                    ::gen-patterns])
    (fn [{:keys [start from end]}]
      (when end
        (assert (t/before? (t/instant start)

--- a/src/main/com/yetanalytics/datasim/input/profile.clj
+++ b/src/main/com/yetanalytics/datasim/input/profile.clj
@@ -26,12 +26,10 @@
                     author]
   p/FromInput
   (validate [this]
-    ;; TODO: We need to validate the Profile's relations
-    ;; to internal and external Patterns.
-    (let [prof-errs (pan/validate-profile this
-                                          :syntax? true
-                                          :pattern-rels? true
-                                          :result :type-path-string)]
+    (let [prof-errs (pan/validate-profile
+                     this
+                     :syntax? true
+                     :result :type-path-string)]
       (errs/type-path-string-m->map-coll id prof-errs)))
 
   p/JSONRepresentable

--- a/src/main/com/yetanalytics/datasim/sim.clj
+++ b/src/main/com/yetanalytics/datasim/sim.clj
@@ -265,7 +265,7 @@
                          lunch-hour-seq])
         ;; activities used in the sim
         activities (activity/derive-cosmos input (.nextLong sim-rng))
-        iri-map (apply p/profiles->map profiles)]
+        iri-map (p/profiles->map profiles)]
     ;; Now, for each actor we 'initialize' what is needed for the sim
     (into {}
           (for [[actor-id actor] (sort-by first (map (juxt xapiu/agent-id
@@ -294,11 +294,11 @@
                       ;; infinite seq of maps containing registration uuid,
                       ;; statement template, and a seed for generation
                       actor-reg-seq (p/registration-seq
-                                     profiles actor-alignment actor-reg-seed)
+                                     iri-map actor-alignment actor-reg-seed)
 
                       ;; additional seed for further gen
                       actor-seed (.nextLong sim-rng)
-                      
+
                       ;; Dissoc :role since it is not an xAPI property
                       actor-xapi (dissoc actor :role)]]
             [actor-id

--- a/src/main/com/yetanalytics/datasim/sim.clj
+++ b/src/main/com/yetanalytics/datasim/sim.clj
@@ -265,7 +265,9 @@
                          lunch-hour-seq])
         ;; activities used in the sim
         activities (activity/derive-cosmos input (.nextLong sim-rng))
-        iri-map (p/profiles->map profiles)]
+        iri-map (-> (p/profiles->map profiles)
+                    ;; Select which primary patterns to generate from
+                    (p/select-primary-patterns parameters))]
     ;; Now, for each actor we 'initialize' what is needed for the sim
     (into {}
           (for [[actor-id actor] (sort-by first (map (juxt xapiu/agent-id

--- a/src/main/com/yetanalytics/datasim/xapi/profile.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile.clj
@@ -2,6 +2,7 @@
   "Understanding elements of xAPI profiles
   Generate Profile walks"
   (:require [clojure.spec.alpha :as s]
+            [com.yetanalytics.datasim.input.parameters :as params]
             [com.yetanalytics.datasim.iri :as iri]
             [com.yetanalytics.datasim.random :as random]
             [com.yetanalytics.pan.objects.profile :as profile]
@@ -11,9 +12,12 @@
             [clojure.zip :as z])
   (:import [java.util Random]))
 
+(s/def ::_profile-id ::profile/id)
 
 (s/def ::iri-map
   (s/map-of iri/iri-spec
+            ;; TODO: using s/and or s/merge to add ::_profile-id won't work
+            ;; It will be present and should be expected
             (s/or :concept ::concept/concept
                   :pattern ::pattern/pattern
                   :template ::template/template)))
@@ -27,10 +31,13 @@
   [profiles]
   (assert (seq profiles) "At least one profile is required.")
   (into {}
-        (for [profile profiles
+        (for [{profile-id :id
+               :as profile} profiles
               [_ things] (select-keys profile [:concepts :patterns :templates])
               {:keys [id] :as thing} things]
-          [id thing])))
+          [id (assoc thing
+                     ::_profile-id
+                     profile-id)])))
 
 (defn loc-iri-map
   "Given a zipper loc, get the map of profile subobjects by IRI"
@@ -197,6 +204,36 @@
        (registration-seq
         root-loc
         rng))))))
+
+(s/fdef select-primary-patterns
+  :args (s/cat :iri-map ::iri-map
+               :params ::params/parameters)
+  :ret ::iri-map)
+
+(defn select-primary-patterns
+  "Given an iri-map and params, select primary patterns for generation"
+  [iri-map
+   {:keys [gen-profiles
+           gen-patterns]}]
+  (let [?profile-set (some-> gen-profiles not-empty set)
+        ?pattern-set (some-> gen-patterns not-empty set)]
+    (reduce-kv
+     (fn [m k {obj-type :type
+               profile-id ::_profile-id
+               :keys [id primary]
+               :as v}]
+       (assoc m k
+              (cond-> v
+                (and (= obj-type "Pattern")
+                     primary)
+                (assoc :primary
+                       (and
+                        (or (nil? ?profile-set)
+                            (contains? ?profile-set profile-id))
+                        (or (nil? ?pattern-set)
+                            (contains? ?pattern-set id)))))))
+     (empty iri-map)
+     iri-map)))
 
 (comment
 

--- a/src/test/com/yetanalytics/datasim/input_test.clj
+++ b/src/test/com/yetanalytics/datasim/input_test.clj
@@ -154,4 +154,21 @@
     (is (try (validate-throw
               (from-location :input :json "dev-resources/input/simple.json"))
              true
-             (catch Exception _ false)))))
+             (catch Exception _ false))))
+  (testing "input is invalid"
+    (testing "with invalid gen-profiles"
+      (is (try
+            (validate-throw
+             (assoc-in (from-location :input :json "dev-resources/input/simple.json")
+                       [:parameters :gen-profiles]
+                       ["http://example.com/nonexistent.jsonld"]))
+            false
+            (catch Exception _ true))))
+    (testing "with invalid gen-patterns"
+      (is (try
+            (validate-throw
+             (assoc-in (from-location :input :json "dev-resources/input/simple.json")
+                       [:parameters :gen-patterns]
+                       ["http://example.com/nonexistent#pattern"]))
+            false
+            (catch Exception _ true))))))

--- a/src/test/com/yetanalytics/datasim/sim_test.clj
+++ b/src/test/com/yetanalytics/datasim/sim_test.clj
@@ -62,6 +62,37 @@
                                          (get s0 "timestamp")))]
       (is (not= s0 s1'))
       (is (= s1 s1'))))
+  (testing "multiple profiles"
+    (let [double-input (update valid-input
+                               :profiles
+                               conj
+                               (input/from-location
+                                :profile
+                                :json
+                                "dev-resources/profiles/tla/mom.jsonld"))]
+      (testing "respects gen-profiles param"
+        (let [ss (-> double-input
+                     (update :parameters
+                             assoc
+                             :gen-profiles
+                             ["https://w3id.org/xapi/cmi5"])
+                     sim-seq)]
+          (is (= [[{"id" "https://w3id.org/xapi/cmi5/v1.0"}]
+                  [{"id" "https://w3id.org/xapi/cmi5/context/categories/moveon"}]]
+                 (-> ss
+                     (->> (map #(get-in % ["context" "contextActivities" "category"])))
+                     distinct)))))
+      (testing "respects gen-patterns param"
+        (let [ss (-> double-input
+                     (update :parameters
+                             assoc
+                             :gen-patterns
+                             ["https://w3id.org/xapi/tla#completed_session"])
+                     sim-seq)]
+          (is (= [nil [{"id" "https://w3id.org/xapi/tla/v0.13"}]]
+                 (-> ss
+                     (->> (map #(get-in % ["context" "contextActivities" "category"])))
+                     distinct)))))))
   (testing "respects agent selection"
     (let [ret (sim-seq (assoc-in valid-input [:parameters :max] 3)
                        ;; specify we only want the given agent(s)

--- a/src/test/com/yetanalytics/datasim/sim_test.clj
+++ b/src/test/com/yetanalytics/datasim/sim_test.clj
@@ -71,28 +71,42 @@
                                 :json
                                 "dev-resources/profiles/tla/mom.jsonld"))]
       (testing "respects gen-profiles param"
-        (let [ss (-> double-input
-                     (update :parameters
-                             assoc
-                             :gen-profiles
-                             ["https://w3id.org/xapi/cmi5"])
-                     sim-seq)]
-          (is (= [[{"id" "https://w3id.org/xapi/cmi5/v1.0"}]
-                  [{"id" "https://w3id.org/xapi/cmi5/context/categories/moveon"}]]
-                 (-> ss
-                     (->> (map #(get-in % ["context" "contextActivities" "category"])))
-                     distinct)))))
+        (is (= [[{"id" "https://w3id.org/xapi/cmi5/v1.0"}]
+                [{"id" "https://w3id.org/xapi/cmi5/context/categories/moveon"}]]
+               (-> double-input
+                   (update :parameters
+                           assoc
+                           :gen-profiles
+                           ["https://w3id.org/xapi/cmi5"])
+                   sim-seq
+                   (->> (map #(get-in % ["context" "contextActivities" "category"])))
+                   distinct))))
       (testing "respects gen-patterns param"
-        (let [ss (-> double-input
-                     (update :parameters
-                             assoc
-                             :gen-patterns
-                             ["https://w3id.org/xapi/tla#completed_session"])
-                     sim-seq)]
-          (is (= [nil [{"id" "https://w3id.org/xapi/tla/v0.13"}]]
-                 (-> ss
-                     (->> (map #(get-in % ["context" "contextActivities" "category"])))
-                     distinct)))))))
+        (is (= [nil [{"id" "https://w3id.org/xapi/tla/v0.13"}]]
+               (-> double-input
+                   (update :parameters
+                           assoc
+                           :gen-patterns
+                           ["https://w3id.org/xapi/tla#completed_session"])
+                   sim-seq
+                   (->> (map #(get-in % ["context" "contextActivities" "category"])))
+                   distinct))))
+      (testing "allows referential use of non-gen profiles"
+        (is (= [nil [{"id" "https://w3id.org/xapi/tla/v0.13"}]]
+               (-> double-input
+                   (update :profiles
+                           conj
+                           (input/from-location
+                            :profile
+                            :json
+                            "dev-resources/profiles/referential.jsonld"))
+                   (update :parameters
+                           assoc
+                           :gen-patterns
+                           ["https://xapinet.org/xapi/yet/referential#completed_session"])
+                   sim-seq
+                   (->> (map #(get-in % ["context" "contextActivities" "category"])))
+                   distinct))))))
   (testing "respects agent selection"
     (let [ret (sim-seq (assoc-in valid-input [:parameters :max] 3)
                        ;; specify we only want the given agent(s)

--- a/src/test/com/yetanalytics/datasim/xapi/profile_test.clj
+++ b/src/test/com/yetanalytics/datasim/xapi/profile_test.clj
@@ -20,14 +20,14 @@
     (is (= '(:zip/branch? :zip/children :zip/make-node ::profile/iri-map)
            (-> test-input
                :profiles
-               first
+               profile/profiles->map
                profile/pattern-zip
                meta
                keys)))
     (is (s/valid? ::profile/iri-map
                   (-> test-input
                       :profiles
-                      first
+                      profile/profiles->map
                       profile/pattern-zip
                       profile/loc-iri-map
                       (dissoc ::profile/root))))
@@ -36,7 +36,7 @@
             :alternates ["https://w3id.org/xapi/cmi5#toplevel"]}
            (-> test-input
                :profiles
-               first
+               profile/profiles->map
                profile/pattern-zip
                profile/loc-iri-map
                ::profile/root)))))
@@ -161,7 +161,7 @@
 (defn gen-single-walk [seed]
   (->>
    (profile/rand-pattern-zip
-    (:profiles test-input)
+    (profile/profiles->map (:profiles test-input))
     (:alignments test-input)
     (random/seed-rng seed))
    profile/walk-once

--- a/src/test/com/yetanalytics/datasim/xapi/statement_test.clj
+++ b/src/test/com/yetanalytics/datasim/xapi/statement_test.clj
@@ -25,7 +25,7 @@
     (let [top-seed 42
           top-rng (random/seed-rng top-seed)
           input (input/from-location :input :json "dev-resources/input/simple.json")
-          iri-map (apply profile/profiles->map (:profiles input))
+          iri-map (profile/profiles->map (:profiles input))
           activities (activity/derive-cosmos input (random/rand-long top-rng))
           valid-args {:input input
                       :iri-map iri-map


### PR DESCRIPTION
[DS-129] Allow the user to specify which profiles and/or patterns they want to generate.

This PR adds the `gen-profiles` and `gen-parameters` options to allow selection of which primary patterns will be used for generation. If either param is absent, all are used.

[DS-129]: https://yet.atlassian.net/browse/DS-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ