### PR TITLE
Update NVD version + fix resulting CVEs

### DIFF
--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -8,7 +8,7 @@ jobs:
   nvd-scan:
     uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.3
     with:
-      nvd-clojure-version: '2.0.0'
+      nvd-clojure-version: '2.9.0'
       classpath-command: 'clojure -Spath -A:cli:server'
       nvd-config-filename: '.nvd/config.json'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   nvd-scan:
     uses: yetanalytics/actions/.github/workflows/nvd-scan.yml@v0.0.3
     with:
-      nvd-clojure-version: '2.0.0'
+      nvd-clojure-version: '2.9.0'
       # onyx dep is outdated and abandoned so don't bother scanning
       classpath-command: 'clojure -Spath -A:cli:server'
       nvd-config-filename: '.nvd/config.json'

--- a/deps.edn
+++ b/deps.edn
@@ -24,13 +24,13 @@
                       com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
                       com.fasterxml.jackson.core/jackson-databind]}
         com.fasterxml.jackson.core/jackson-core
-        {:mvn/version "2.13.2"}
+        {:mvn/version "2.13.4"}
         com.fasterxml.jackson.dataformat/jackson-dataformat-smile
-        {:mvn/version "2.13.2"}
+        {:mvn/version "2.13.4"}
         com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
-        {:mvn/version "2.13.2"}
+        {:mvn/version "2.13.4"}
         com.fasterxml.jackson.core/jackson-databind
-        {:mvn/version "2.13.2.1"}}
+        {:mvn/version "2.13.4.2"}}
  :aliases
  {:cli {:extra-paths ["src/cli"]
         :extra-deps {org.clojure/tools.cli {:git/url "https://github.com/clojure/tools.cli"


### PR DESCRIPTION
Bumps the nvd-clojure version used to 2.9.0 and fixes CVE-2022-42004 and CVE-2022-42003 by updating the jackson-databind version.