### PR TITLE
exclude msgpack to clear CVE-2022-41719

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -50,7 +50,8 @@
   :server
   {:extra-paths ["src/server"]
    :extra-deps
-   {io.pedestal/pedestal.service             {:mvn/version "0.5.10"}
+   {io.pedestal/pedestal.service             {:mvn/version "0.5.10"
+                                              :exclusions [org.msgpack/msgpack]}
     io.pedestal/pedestal.jetty
     {:mvn/version "0.5.10"
      :exclusions


### PR DESCRIPTION
Likely an FP, but it is not used so should be safe to remove.