### PR TITLE
[DS-137][DS-139] CLI and Server refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ This endpoint takes a set of simulation inputs, returns a file with the output d
 
     profiles: Array of json-ld xAPI Profiles
 
-    personae: JSON Object containing Actors formatted as above
+    personae-array: Array of JSON Objects containing Actors formatted as above
 
     alignments: JSON Object containing Alignments formatted as above
 

--- a/src/cli/com/yetanalytics/datasim/main.clj
+++ b/src/cli/com/yetanalytics/datasim/main.clj
@@ -212,8 +212,7 @@
                         :password   password}]
       (if async
         (post-async! input post-options post-limit select-agents concurrency)
-        (post-sync! input post-options post-limit select-agents))
-      (System/exit 0))))
+        (post-sync! input post-options post-limit select-agents)))))
 
 ;; Print sim to stdout ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/cli/com/yetanalytics/datasim/main.clj
+++ b/src/cli/com/yetanalytics/datasim/main.clj
@@ -10,6 +10,10 @@
             [com.yetanalytics.datasim.util.errors :as errors])
   (:gen-class))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; CLI Input
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (defn- conj-input
   "Conj the input (either a Profile or a personae) to return a
    vector of inputs, e.g. `-p profile-1 -p profile-2` becomes
@@ -112,8 +116,12 @@
    [nil "--gen-pattern IRI" "Only generate based on the given primary pattern. May be given multiple times to include multiple patterns."
     :id :gen-patterns
     :assoc-fn conj-param-input]
-
+   ;; Help
    ["-h" "--help"]])
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; CLI Run
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn bail!
   "Print error messages to std error and exit."
@@ -125,139 +133,160 @@
     (flush)
     (System/exit status)))
 
-;; TODO: Use I/O util functions to write to *out*
-(defn- run-sim!
-  "Generate statement seqs and writes them to stdout."
-  [input & rest-args]
-  (doseq [statement-seq (apply ds/generate-seq input rest-args)]
-    (json/generate-stream statement-seq *out*)
-    (.write *out* "\n")
-    (flush)))
-
-(defn -main [& args]
-  (let [{:keys [options
-                arguments
-                summary
-                errors]
-         :as parsed-opts}
-        (cli/parse-opts
-         args
-         (cli-options
-          ;; if the verb is "validate-input", we
-          ;; skip tools.cli validation and do a
-          ;; more in-depth one.
-          (not= "validate-input" (last args))))
-        [?command & rest-args] arguments]
-    (cond (seq errors)
-          (bail! errors)
-
-          (or (empty? args) (:help options))
-          (println summary)
-
-          :else
-          ;; At this point, we have valid individual inputs. However, there may
-          ;; be cross-validation that needs to happen, so we compose the
-          ;; comprehensive spec from the options and check that.
-          (let [sim-options (select-keys options
-                                         [:input
+(defn- sim-input [options]
+  (let [sim-options (select-keys options [:input
                                           :profiles
                                           :personae-array
                                           :parameters
                                           :alignments])
-                {:keys [override-seed
-                        select-agents]} options
-                input (cond-> (or (:input sim-options)
-                                  (dissoc sim-options :input))
-                        override-seed
-                        (assoc-in [:parameters :seed]
-                                  (if (= -1 override-seed)
-                                    (random/rand-unbound-int (random/rng))
-                                    override-seed)))]
-            (if-let [errors (not-empty (input/validate :input input))]
-              (bail! (errors/map-coll->strs errors))
-              (if ?command
-                (case ?command
-                  ;; Where the CLI will actually perform generation
-                  "generate"
-                  (if (= "post" (first rest-args))
-                    ;; Attempt to post to an LRS
-                    (let [{:keys [endpoint
-                                  username
-                                  password
-                                  batch-size
-                                  concurrency
-                                  post-limit
-                                  async]} options
-                          ]
-                      (if endpoint
-                        (let [post-options (cond-> {:endpoint endpoint
-                                                    :batch-size batch-size}
-                                             (and username password)
-                                             (assoc-in [:http-options :basic-auth] [username password]))]
-                          (if async
-                            ;; ASYNC Operation
-                            (let [sim-chan (ds/generate-seq-async
-                                            (cond-> input
-                                              ;; when async, we just use the post
-                                              ;; limit as the max
-                                              (not= post-limit -1)
-                                              (assoc-in [:parameters :max] post-limit)
-                                              )
-                                            :select-agents select-agents)
-                                  result-chan (http/post-statements-async
-                                               post-options
-                                               sim-chan
-                                               :concurrency concurrency)]
+        {:keys [override-seed]} options]
+    (cond-> (or (:input sim-options)
+                (dissoc sim-options :input))
+      override-seed
+      (assoc-in [:parameters :seed]
+                (if (= -1 override-seed)
+                  (random/rand-unbound-int (random/rng))
+                  override-seed)))))
 
-                              (loop []
-                                (if-let [[tag ret] (a/<!! result-chan)]
-                                  (case tag
-                                    :fail
-                                    (let [{:keys [status error]} ret]
-                                      (bail! [(format "LRS Request FAILED with STATUS: %d, MESSAGE:%s"
-                                                      status (or (some-> error ex-message) "<none>"))]))
-                                    :success
-                                    (do
-                                      (doseq [^java.util.UUID id ret]
-                                        (printf "%s\n" (.toString ^java.util.UUID id))
-                                        (flush))
-                                      (recur)))
-                                  (System/exit 0))))
-                            ;; SYNC operation
-                            (let [statements (cond->> (ds/generate-seq
-                                                       input
-                                                       :select-agents select-agents)
-                                               (not= post-limit -1)
-                                               (take post-limit))
-                                  {:keys [success ;; Count of successfully transacted statements
-                                          fail ;; list of failed requests
-                                          ]
-                                   :as post-results} (http/post-statements
-                                                      post-options
-                                                      statements
-                                                      :emit-ids-fn
-                                                      (fn [ids]
-                                                        (doseq [^java.util.UUID id ids]
-                                                          (printf "%s\n" (.toString id))
-                                                          (flush))))]
-                              (if (not-empty fail)
-                                (bail! (for [{:keys [status error]} fail]
-                                         (format "LRS Request FAILED with STATUS: %d, MESSAGE:%s"
-                                                 status (or (some-> error ex-message) "<none>"))))
-                                (System/exit 0)))))
-                        ;; Endpoint is required when posting
-                        (bail! ["-E / --endpoint REQUIRED for post."])))
-                    ;; Stdout
-                    (run-sim! input :select-agents select-agents))
+;; When this is called, we should have valid individual inputs. However, there
+;; may be cross-validation that needs to happen, so we compose the
+;; comprehensive spec from the options and check that.
+(defn- assert-valid-input [input]
+  (when-let [errors (not-empty (input/validate :input input))]
+    (bail! (errors/map-coll->strs errors))))
 
-                  ;; If they just want to validate and we're this far, we're done.
-                  ;; Just return the input spec as JSON
-                  "validate-input"
-                  (let [[location] rest-args]
-                    (if location
-                      (do (input/to-file input :json location)
-                          (println (format "Input specification written to %s" location)))
-                      ;; TODO: Figure out why we get a stream closed error here
-                      (input/to-out input :json))))
-                (do (println "No command entered.")
-                    (println summary))))))))
+;; POST to LRS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- lrs-error-message [status error]
+  (format "LRS Request FAILED with STATUS: %d, MESSAGE:%s"
+          status
+          (or (some-> error ex-message) "<none>")))
+
+(defn- print-uuids [uuid-coll]
+  (doseq [^java.util.UUID id uuid-coll]
+    (printf "%s\n" (.toString id))
+    (flush)))
+
+(defn- post-async!
+  [input post-options post-limit select-agents concurrency]
+  (let [gen-input   (cond-> input
+                      ;; when async, we just use the post
+                      ;; limit as the max
+                      (not= post-limit -1)
+                      (assoc-in [:parameters :max] post-limit))
+        sim-chan    (ds/generate-seq-async
+                     gen-input
+                     :select-agents select-agents)
+        result-chan (http/post-statements-async
+                     post-options
+                     sim-chan
+                     :concurrency concurrency)]
+    (loop []
+      (when-let [[tag ret] (a/<!! result-chan)]
+        (case tag
+          :fail
+          (let [{:keys [status error]} ret]
+            (bail! [(lrs-error-message status error)]))
+          :success
+          (do
+            (print-uuids ret)
+            (recur)))))))
+
+(defn- post-sync!
+  [input post-options post-limit select-agents]
+  (let [statements (cond->> (ds/generate-seq
+                             input
+                             :select-agents select-agents)
+                     (not= post-limit -1)
+                     (take post-limit))
+        {:keys [fail]}
+        (http/post-statements post-options
+                              statements
+                              :emit-ids-fn print-uuids)]
+    (when (not-empty fail)
+      (bail! (for [{:keys [status error]} fail]
+               (lrs-error-message status error))))))
+
+(defn- post-sim!
+  [input options]
+  (let [{:keys [endpoint
+                username
+                password
+                batch-size
+                concurrency
+                post-limit
+                select-agents
+                async]}
+        options]
+    ;; Endpoint is required when posting
+    (when-not endpoint
+      (bail! ["-E / --endpoint REQUIRED for post."]))
+    ;; Endpoint present - OK
+    (let [post-options
+          (cond-> {:endpoint   endpoint
+                   :batch-size batch-size}
+            (and username password)
+            (assoc-in [:http-options :basic-auth] [username password]))]
+      (if async
+        (post-async! input post-options post-limit select-agents concurrency)
+        (post-sync! input post-options post-limit select-agents))
+      (System/exit 0))))
+
+;; Print sim to stdout ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; TODO: Use I/O util functions to write to *out*
+(defn- print-sim!
+  "Generate statement seqs and writes them to stdout."
+  [input {:keys [select-agents]}]
+  (doseq [statement-seq (ds/generate-seq input :select-agents select-agents)]
+    (json/generate-stream statement-seq *out*)
+    (.write *out* "\n")
+    (flush)))
+
+;; Write Input mode ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- write-input!
+  ([input]
+   ;; TODO: Figure out why we get a stream closed error here
+   (input/to-out input :json))
+  ([input location]
+   (input/to-file input :json location)
+   (println (format "Input specification written to %s" location))))
+
+;; Main function ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn -main [& args]
+  (let [;; If the verb is "validate-input", we
+        ;; skip tools.cli validation and do a
+        ;; more in-depth one.
+        cli-opts
+        (cli-options (not= "validate-input" (last args)))
+        {:keys [options arguments summary errors]}
+        (cli/parse-opts args cli-opts)
+        [?command & rest-args]
+        arguments]
+    (cond
+      ;; Invalid CLI input
+      (seq errors)
+      (bail! errors)
+      ;; Help
+      (or (empty? args) (:help options))
+      (println summary)
+      :else
+      (let [input (sim-input options)]
+        (assert-valid-input input)
+        (case ?command
+          ;; Where the CLI will actually perform generation
+          "generate"
+          (if (= "post" (first rest-args))
+            (post-sim! input options)
+            (print-sim! input options))
+          ;; If they just want to validate and we're this far, we're done.
+          ;; Just return the input spec as JSON.
+          "validate-input"
+          (if-some [location (first rest-args)]
+            (write-input! input location)
+            (write-input! input))
+          ;; No command
+          (do (println "No command entered.")
+              (println summary)))))))

--- a/src/cli/com/yetanalytics/datasim/main.clj
+++ b/src/cli/com/yetanalytics/datasim/main.clj
@@ -1,13 +1,13 @@
 (ns com.yetanalytics.datasim.main
   (:require [clojure.core.async :as a]
             [clojure.tools.cli  :as cli]
-            [com.yetanalytics.datasim :as ds]
-            [com.yetanalytics.datasim.client :as http]
-            [com.yetanalytics.datasim.input  :as input]
+            [com.yetanalytics.datasim                  :as ds]
+            [com.yetanalytics.datasim.client           :as client]
+            [com.yetanalytics.datasim.input            :as input]
             [com.yetanalytics.datasim.input.parameters :as params]
-            [com.yetanalytics.datasim.math.random :as random]
-            [com.yetanalytics.datasim.util.errors :as errors]
-            [com.yetanalytics.datasim.util.io     :as dio])
+            [com.yetanalytics.datasim.math.random      :as random]
+            [com.yetanalytics.datasim.util.errors      :as errors]
+            [com.yetanalytics.datasim.util.io          :as dio])
   (:gen-class))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -164,7 +164,7 @@
         sim-chan    (ds/generate-seq-async
                      gen-input
                      :select-agents select-agents)
-        result-chan (http/post-statements-async
+        result-chan (client/post-statements-async
                      post-options
                      sim-chan
                      :concurrency concurrency)]
@@ -173,7 +173,7 @@
         (case tag
           :fail
           (let [{:keys [status error]} ret]
-            (bail! [(http/post-error-message status error)]))
+            (bail! [(client/post-error-message status error)]))
           :success
           (do
             (dio/println-coll ret) ; Statement ID strings
@@ -186,10 +186,10 @@
                                  :select-agents select-agents)
                          (not= post-limit -1)
                          (take post-limit))
-        {:keys [fail]} (http/post-statements post-options statements)]
+        {:keys [fail]} (client/post-statements post-options statements)]
     (when (not-empty fail)
       (bail! (for [{:keys [status error]} fail]
-               (http/post-error-message status error))))))
+               (client/post-error-message status error))))))
 
 (defn- post-sim!
   [input options]

--- a/src/cli/com/yetanalytics/datasim/main.clj
+++ b/src/cli/com/yetanalytics/datasim/main.clj
@@ -1,16 +1,13 @@
 (ns com.yetanalytics.datasim.main
-  (:require [clojure.tools.cli :as cli :refer [parse-opts]]
-            [clojure.spec.alpha :as s]
-            [clojure.core.async :as a]
+  (:require [clojure.core.async :as a]
+            [clojure.tools.cli  :as cli]
             [cheshire.core      :as json]
             [com.yetanalytics.datasim :as ds]
-            [com.yetanalytics.datasim.input :as input]
-            [com.yetanalytics.datasim.util.errors :as errors]
-            [com.yetanalytics.datasim.input.parameters :as params]
             [com.yetanalytics.datasim.client :as http]
+            [com.yetanalytics.datasim.input  :as input]
+            [com.yetanalytics.datasim.input.parameters :as params]
             [com.yetanalytics.datasim.math.random :as random]
-            [clojure.pprint :refer [pprint]])
-  (:import [java.util Random])
+            [com.yetanalytics.datasim.util.errors :as errors])
   (:gen-class))
 
 (defn- conj-input
@@ -142,13 +139,14 @@
                 arguments
                 summary
                 errors]
-         :as parsed-opts} (parse-opts args
-                                      (cli-options
-                                       ;; if the verb is "validate-input", we
-                                       ;; skip tools.cli validation and do a
-                                       ;; more in-depth one.
-                                       (not= "validate-input"
-                                             (last args))))
+         :as parsed-opts}
+        (cli/parse-opts
+         args
+         (cli-options
+          ;; if the verb is "validate-input", we
+          ;; skip tools.cli validation and do a
+          ;; more in-depth one.
+          (not= "validate-input" (last args))))
         [?command & rest-args] arguments]
     (cond (seq errors)
           (bail! errors)

--- a/src/cli/com/yetanalytics/datasim/main.clj
+++ b/src/cli/com/yetanalytics/datasim/main.clj
@@ -176,7 +176,7 @@
             (bail! [(http/post-error-message status error)]))
           :success
           (do
-            (dio/println-coll (map str ret))
+            (dio/println-coll ret) ; Statement ID strings
             (recur)))))))
 
 (defn- post-sync!

--- a/src/main/com/yetanalytics/datasim/client.clj
+++ b/src/main/com/yetanalytics/datasim/client.clj
@@ -4,8 +4,7 @@
             [clojure.java.io    :as io]
             [cheshire.core      :as json]
             [org.httpkit.client :as http]
-            [com.yetanalytics.datasim.util.io :as dio])
-  (:import [java.util UUID]))
+            [com.yetanalytics.datasim.util.io :as dio]))
 
 (defn post-error-message [status error]
   (format "POST Request FAILED with STATUS: %d, MESSAGE:%s"
@@ -15,10 +14,6 @@
 (def default-http-options
   {:headers {"X-Experience-Api-Version" "1.0.3"
              "Content-Type" "application/json"}})
-
-;; TODO: These UUIDs are never used as UUIDs, only as strings
-(defn- id->uuid [^String id]
-  (UUID/fromString id))
 
 (defn- decode-body [body]
   (with-open [rdr (io/reader body)]
@@ -68,9 +63,9 @@
           (if (= 200 status)
             ;; Success!
             ;; FIXME: Shouldn't other codes like 204 be supported?
-            (let [statement-ids (map id->uuid (decode-body body))]
+            (let [statement-ids (decode-body body)]
               (when print-ids?
-                (dio/println-coll (map str statement-ids)))
+                (dio/println-coll statement-ids))
               (recur (rest batches)
                      (+ success (count statement-ids))
                      fail))
@@ -114,7 +109,7 @@
                         (a/put! port [:fail ret]))
                       ;; Success: Continue
                       (a/put! port
-                              [:success (mapv id->uuid (decode-body body))]))
+                              [:success (decode-body body)]))
                     ;; Close the return channel
                     (a/close! port))
         async-fn (fn [batch port]

--- a/src/main/com/yetanalytics/datasim/client.clj
+++ b/src/main/com/yetanalytics/datasim/client.clj
@@ -3,7 +3,8 @@
   (:require [clojure.core.async :as a]
             [clojure.java.io    :as io]
             [cheshire.core      :as json]
-            [org.httpkit.client :as http])
+            [org.httpkit.client :as http]
+            [com.yetanalytics.datasim.util.io :as dio])
   (:import [java.util UUID]))
 
 (defn post-error-message [status error]
@@ -15,6 +16,7 @@
   {:headers {"X-Experience-Api-Version" "1.0.3"
              "Content-Type" "application/json"}})
 
+;; TODO: These UUIDs are never used as UUIDs, only as strings
 (defn- id->uuid [^String id]
   (UUID/fromString id))
 
@@ -42,11 +44,6 @@
               (post-options http-options batch)
               callback-fn)))
 
-(defn- print-uuids [uuid-coll]
-  (doseq [^java.util.UUID id uuid-coll]
-    (printf "%s\n" (.toString id))
-    (flush)))
-
 (defn post-statements
   "Given LRS options and a `statement-seq`, send them to an LRS in synchronous
    batches. If `print-ids?` is `true`, returned statement IDs will be printed
@@ -73,7 +70,7 @@
             ;; FIXME: Shouldn't other codes like 204 be supported?
             (let [statement-ids (map id->uuid (decode-body body))]
               (when print-ids?
-                (print-uuids statement-ids))
+                (dio/println-coll (map str statement-ids)))
               (recur (rest batches)
                      (+ success (count statement-ids))
                      fail))

--- a/src/main/com/yetanalytics/datasim/client.clj
+++ b/src/main/com/yetanalytics/datasim/client.clj
@@ -6,6 +6,11 @@
             [org.httpkit.client :as http])
   (:import [java.util UUID]))
 
+(defn post-error-message [status error]
+  (format "POST Request FAILED with STATUS: %d, MESSAGE:%s"
+          status
+          (or (some-> error ex-message) "<none>")))
+
 (def default-http-options
   {:headers {"X-Experience-Api-Version" "1.0.3"
              "Content-Type" "application/json"}})
@@ -37,50 +42,61 @@
               (post-options http-options batch)
               callback-fn)))
 
+(defn- print-uuids [uuid-coll]
+  (doseq [^java.util.UUID id uuid-coll]
+    (printf "%s\n" (.toString id))
+    (flush)))
+
 (defn post-statements
-  "Given LRS options and a statement seq, send them to an LRS in synchronous
-   batches. If an `emit-ids-fn` is given it will be called with posted statement
-   IDs on success."
+  "Given LRS options and a `statement-seq`, send them to an LRS in synchronous
+   batches. If `print-ids?` is `true`, returned statement IDs will be printed
+   to stdout. `username` and `password` in the options map are the Basic Auth
+   credentials of the LRS."
   [{:keys [endpoint
            batch-size
-           http-options]
+           username
+           password]
     :or {batch-size 25}}
    statement-seq
-   & {:keys [emit-ids-fn]}]
+   & {:keys [print-ids?]
+      :or   {print-ids? true}}]
   ;; TODO: Exponential backoff, etc
-  (loop [batches (partition-all batch-size statement-seq)
-         success 0
-         fail    []]
-    (if-let [batch (first batches)]
-      (let [{:keys [status body] :as response}
-            @(post-batch endpoint http-options batch)]
-        (if (= 200 status)
-          ;; Success!
-          ;; FIXME: Shouldn't other codes like 204 be supported?
-          (let [statement-ids (map id->uuid (decode-body body))]
-            (when emit-ids-fn
-              (emit-ids-fn statement-ids))
-            (recur (rest batches)
-                   (+ success (count statement-ids))
-                   fail))
-          ;; Failure
-          (let [response* (cond-> response
-                            body (assoc :body (decode-body body)))]
-            {:success success
-             :fail    (conj fail response*)})))
-      ;; Batch finished POSTing
-      {:success success
-       :fail    fail})))
+  (let [http-options {:basic-auth [username password]}]
+    (loop [batches (partition-all batch-size statement-seq)
+           success 0
+           fail    []]
+      (if-let [batch (first batches)]
+        (let [{:keys [status body] :as response}
+              @(post-batch endpoint http-options batch)]
+          (if (= 200 status)
+            ;; Success!
+            ;; FIXME: Shouldn't other codes like 204 be supported?
+            (let [statement-ids (map id->uuid (decode-body body))]
+              (when print-ids?
+                (print-uuids statement-ids))
+              (recur (rest batches)
+                     (+ success (count statement-ids))
+                     fail))
+            ;; Failure
+            (let [response* (cond-> response
+                              body (assoc :body (decode-body body)))]
+              {:success success
+               :fail    (conj fail response*)})))
+        ;; Batch finished POSTing
+        {:success success
+         :fail    fail}))))
 
 (defn post-statements-async
   "Given LRS options and a channel with statements, send them to an LRS in
-   asynchronous batches.
+   asynchronous batches. `username` and `password` in the options map are the
+   Basic Auth credentials of the LRS.
 
    Returns a channel that will reciveve `[:success <list of statement ids>]`
    for each batch or `[:fail <failing request>]`. Will stop sending on failure."
   [{:keys [endpoint
            batch-size
-           http-options]
+           username
+           password]
     :or {batch-size 25}}
    statement-chan
    & {:keys [concurrency
@@ -89,24 +105,25 @@
       :or {concurrency 4
            buffer-in   100 ; 10x default batch size
            buffer-out  100}}]
-  (let [run?     (atom true)
-        in-chan  (a/chan buffer-in (partition-all batch-size))
-        out-chan (a/chan buffer-out) ; is this.. backpressure?
-        callback (fn [port {:keys [status body error] :as ret}]
-                   (if (or (not= 200 status) error)
-                     ;; Error: Stop further processing
-                     (do
-                       (swap! run? not)
-                       (a/put! port [:fail ret]))
-                     ;; Success: Continue
-                     (a/put! port
-                             [:success (mapv id->uuid (decode-body body))]))
-                   ;; Close the return channel
-                   (a/close! port))
+  (let [http-opts {:basic-auth [username password]}
+        run?      (atom true)
+        in-chan   (a/chan buffer-in (partition-all batch-size))
+        out-chan  (a/chan buffer-out) ; is this.. backpressure?
+        callback  (fn [port {:keys [status body error] :as ret}]
+                    (if (or (not= 200 status) error)
+                      ;; Error: Stop further processing
+                      (do
+                        (swap! run? not)
+                        (a/put! port [:fail ret]))
+                      ;; Success: Continue
+                      (a/put! port
+                              [:success (mapv id->uuid (decode-body body))]))
+                    ;; Close the return channel
+                    (a/close! port))
         async-fn (fn [batch port]
                    (let [callback (partial callback port)]
                      (if @run?
-                       (post-batch endpoint http-options batch callback)
+                       (post-batch endpoint http-opts batch callback)
                        (a/close! port))))]
     (a/pipeline-async concurrency out-chan async-fn in-chan)
     ;; Pipe to in-chan

--- a/src/main/com/yetanalytics/datasim/client.clj
+++ b/src/main/com/yetanalytics/datasim/client.clj
@@ -1,13 +1,15 @@
 (ns com.yetanalytics.datasim.client
-  "Simple xAPI LRS client fns"
+  "Simple xAPI LRS client functions."
   (:require [clojure.core.async :as a]
             [clojure.java.io    :as io]
             [cheshire.core      :as json]
             [org.httpkit.client :as http]
             [com.yetanalytics.datasim.util.io :as dio]))
 
-(defn post-error-message [status error]
-  (format "POST Request FAILED with STATUS: %d, MESSAGE:%s"
+(defn post-error-message
+  "Error message for when POSTing to an LRS fails."
+  [status error]
+  (format "POST Request FAILED with STATUS: %d, MESSAGE: %s"
           status
           (or (some-> error ex-message) "<none>")))
 

--- a/src/main/com/yetanalytics/datasim/input.clj
+++ b/src/main/com/yetanalytics/datasim/input.clj
@@ -118,9 +118,10 @@
   (throw-unknown-format format-k))
 
 (defmethod to-out :json [data _]
-  (dio/write-json-location data *out*))
+  (dio/write-json-stdout data))
 
 ;; Write to stderr
+;; TODO: Currently unused
 
 (defmulti to-err (fn [_ fmt-k] fmt-k))
 
@@ -128,7 +129,7 @@
   (throw-unknown-format format-k))
 
 (defmethod to-err :json [data _]
-  (dio/write-json-location data *err*))
+  (dio/write-json-stderr data))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Input Validation

--- a/src/main/com/yetanalytics/datasim/util/io.clj
+++ b/src/main/com/yetanalytics/datasim/util/io.clj
@@ -65,21 +65,25 @@
        (catch Exception e
          (throw-unparse-error location e))))
 
-(defn write-json-location
-  "Write the contents of `data` to the `location`, which can be `*out*`
-   for stdout or `*err*` for stderr."
-  [data location]
-  (try (if (#{*out* *err*} location)
-         ;; Write to stdout or stderr
-         (let [w (io/writer location)]
-           (write-json! data location w)
-           (.write w "\n")
-           (.flush w))
-         ;; Write to a file
-         (with-open [w (io/writer location)]
-           (write-json! data location w)))
-       (catch IOException e
-         (throw-io-error location e))))
+;; Avoid `with-open` to prevent stdout/stderr writers from being closed
+
+(defn write-json-stdout
+  "Write the contents of `data` to standard output."
+  [data]
+  (let [w (io/writer *out*)]
+    (write-json data w)
+    (.write w "\n")
+    (.flush w)))
+
+(defn write-json-stderr
+  "Write the contents of `data` to standard error."
+  [data]
+  (let [w (io/writer *err*)]
+    (write-json data w)
+    (.write w "\n")
+    (.flush w)))
+
+;; Use `with-open` to ensure that the file writer gets closed
 
 (defn write-json-file
   "Write the contents of `data` to the file `location`; a file will be

--- a/src/main/com/yetanalytics/datasim/util/io.clj
+++ b/src/main/com/yetanalytics/datasim/util/io.clj
@@ -8,16 +8,14 @@
 ;; Exceptions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- throw-parse-error [location cause-exn]
+(defn- throw-parse-error [cause-exn]
   (throw (ex-info "Parse Error"
-                  {:type     ::parse-error
-                   :location location}
+                  {:type ::parse-error}
                   cause-exn)))
 
-(defn- throw-unparse-error [location cause-exn]
+(defn- throw-unparse-error [cause-exn]
   (throw (ex-info "Unparse Error"
-                  {:type     ::unparse-error
-                   :location location}
+                  {:type ::unparse-error}
                   cause-exn)))
 
 (defn- throw-io-error [location cause-exn]
@@ -47,6 +45,7 @@
 ;; JSON I/O Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; TODO: Also have a `key-fn?` kwarg here?
 (defn read-json-location
   "Reads in a file from the given `location` and parses it into EDN. If
    the data being read is an array or sequence, return all the data
@@ -55,31 +54,38 @@
   (try (with-open [r (io/reader location)]
          (try (doall (json/parse-stream r keywordize-json-key))
               (catch Exception e
-                (throw-parse-error location e))))
+                (throw-parse-error e))))
        (catch IOException e
          (throw-io-error location e))))
 
-(defn- write-json!
-  [data location writer]
-  (try (json/generate-stream data writer {:key-fn stringify-edn-key})
+(defn write-json
+  "Write the contents of `data` to `writer`, which can be returned by
+  `clojure.java.io/writer`. Applies `stringify-edn-key` if `key-fn?` is
+   `true`."
+  [data writer & {:keys [key-fn?] :or {key-fn? true}}]
+  (try (if key-fn?
+         (json/generate-stream data writer {:key-fn stringify-edn-key})
+         (json/generate-stream data writer))
        (catch Exception e
-         (throw-unparse-error location e))))
+         (throw-unparse-error e))))
 
 ;; Avoid `with-open` to prevent stdout/stderr writers from being closed
 
 (defn write-json-stdout
-  "Write the contents of `data` to standard output."
-  [data]
+  "Write the contents of `data` to standard output. Applies `stringify-edn-key`
+   if `key-fn?` is `true`."
+  [data & {:keys [key-fn?] :or {key-fn? true}}]
   (let [w (io/writer *out*)]
-    (write-json data w)
+    (write-json data w :key-fn? key-fn?)
     (.write w "\n")
     (.flush w)))
 
 (defn write-json-stderr
-  "Write the contents of `data` to standard error."
-  [data]
+  "Write the contents of `data` to standard error. Applies `stringify-edn-key`
+   if `key-fn?` is `true`."
+  [data & {:keys [key-fn?] :or {key-fn? true}}]
   (let [w (io/writer *err*)]
-    (write-json data w)
+    (write-json data w :key-fn? key-fn?)
     (.write w "\n")
     (.flush w)))
 
@@ -87,9 +93,29 @@
 
 (defn write-json-file
   "Write the contents of `data` to the file `location`; a file will be
-   created if it does not exist."
-  [data location]
+   created if it does not exist. Stringifies keyword keys. Applies
+   `stringify-edn-key` if `key-fn?` is `true`."
+  [data location & {:keys [key-fn?] :or {key-fn? true}}]
   (let [file (io/file location)]
     (io/make-parents file)
     (with-open [w (io/writer location)]
-      (write-json! data location w))))
+      (write-json data w :key-fn? key-fn?))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; String I/O Functions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn println-coll
+  "Print each string in `str-coll` followed by a newline to stdout,
+   flushing the output buffer after each line."
+  [str-coll]
+  (doseq [s str-coll]
+    (println s)
+    (flush)))
+
+(defn println-err-coll
+  "Print each string in `err-str-coll` followed by a newline to stderr,
+   flushing the output buffer after each line."
+  [err-str-coll]
+  (binding [*out* *err*]
+    (println-coll err-str-coll)))

--- a/src/server/com/yetanalytics/datasim/server.clj
+++ b/src/server/com/yetanalytics/datasim/server.clj
@@ -2,7 +2,6 @@
   (:require [environ.core                      :refer [env]]
             [clojure.string                    :as cstr]
             [clojure.java.io                   :as io]
-            [cheshire.core                     :as json]
             [buddy.auth                        :as auth]
             [buddy.auth.backends               :as backends]
             [buddy.auth.middleware             :as middleware]
@@ -15,7 +14,8 @@
             [io.pedestal.interceptor.error     :as error]
             [com.yetanalytics.datasim          :as ds]
             [com.yetanalytics.datasim.input    :as input]
-            [com.yetanalytics.datasim.client   :as client])
+            [com.yetanalytics.datasim.client   :as client]
+            [com.yetanalytics.datasim.util.io  :as dio])
   (:import [javax.servlet ServletOutputStream])
   (:gen-class))
 
@@ -87,7 +87,7 @@
                         (log/error :msg
                                    (client/post-error-message status error))))))
                 (doseq [statement statement-batch]
-                  (json/generate-stream statement w)
+                  (dio/write-json statement w :key-fn? false)
                   (.write w "\n"))))
             (catch Exception e
               (log/error :msg "Error Building Simulation Skeleton"

--- a/src/server/com/yetanalytics/datasim/server.clj
+++ b/src/server/com/yetanalytics/datasim/server.clj
@@ -136,7 +136,9 @@
 (def response-headers
   {"Content-Type" "application/json; charset=utf-8"})
 
-(defn health-interceptor
+;; Ring handlers are used as interceptors in Pedestal, but are not exclusive
+;; to Pedestal, hence this is not strictly an interceptor.
+(defn health-handler
   "Route implementation for the health endpoint.
    Returns a 200 OK if the server is up and running."
   [_]
@@ -240,7 +242,7 @@
 
 (defn- routes [root-path]
   (-> #{[(str root-path "/health")
-         :get        health-interceptor
+         :get        health-handler
          :route-name :datasim.route/health]
         [(str root-path "/api/v1/generate")
          :post (into common-interceptors

--- a/src/test/com/yetanalytics/datasim/input/profile_test.clj
+++ b/src/test/com/yetanalytics/datasim/input/profile_test.clj
@@ -54,7 +54,7 @@
   (testing "is valid when written"
     (let [^File tf (File/createTempFile "profiletest" nil)]
       (try
-        (dio/write-json-location minimal-profile tf)
+        (dio/write-json-file minimal-profile tf)
         (is (nil? (pan/validate-profile
                    (json/read-str (slurp tf) :key-fn profile-key))))
         (finally


### PR DESCRIPTION
- Refactor + extract out functions (incl. common ones to `datasim.client`)
- Remove redundant seq generation in server by only POSTing and printing statement batches
- Use `datasim.util.io` functions more extensively
- Remove unnecessary UUID coercion in `datasim.client`
- Tiny fix to personae documentation