### PR TITLE
Clojure 1.11 refactoring

### DIFF
--- a/src/cli/com/yetanalytics/datasim/main.clj
+++ b/src/cli/com/yetanalytics/datasim/main.clj
@@ -75,7 +75,8 @@
                 [])]
    [nil "--seed SEED" "Override input seed"
     :id :override-seed
-    :parse-fn #(Integer/parseInt %)
+    :parse-fn parse-long
+    :validate [int? "Seed is not an integer."]
     :desc "An integer seed to override the one in the input spec. Use -1 for random."]
    [nil "--actor AGENT_ID" "Select actor(s) by agent ID"
     :id :select-agents
@@ -95,17 +96,20 @@
    ["-B" "--batch-size SIZE" "LRS POST batch size"
     :id :batch-size
     :default 25
-    :parse-fn #(Integer/parseInt %)
+    :parse-fn parse-long
+    :validate [int? "Batch size is not an integer."]
     :desc "The batch size for POSTing to an LRS"]
    ["-C" "--concurrency CONC" "LRS POST concurrency"
     :id :concurrency
     :default 4
-    :parse-fn #(Integer/parseInt %)
+    :parse-fn parse-long
+    :validate [int? "Concurrency is not an integer."]
     :desc "The max concurrency of the LRS POST pipeline"]
    ["-L" "--post-limit LIMIT" "LRS POST total statement limit"
     :id :post-limit
     :default 999
-    :parse-fn #(Integer/parseInt %)
+    :parse-fn parse-long
+    :validate [int? "POST statement limit is not an integer."]
     :desc "The total number of statements that will be sent to the LRS before termination. Overrides sim params. Set to -1 for no limit."]
    ["-A" "--[no-]async" "Async operation. Use --no-async if statements must be sent to server in timestamp order."
     :id :async

--- a/src/dev/series.clj
+++ b/src/dev/series.clj
@@ -1,5 +1,5 @@
 (ns series
-  (:require [java-time       :as t]
+  (:require [java-time.api   :as t]
             [incanter.core   :refer [view]]
             [incanter.charts :refer [histogram time-series-plot]]
             [incanter.stats  :as stats]

--- a/src/dev_onyx/com/yetanalytics/datasim/onyx/dev_peer.clj
+++ b/src/dev_onyx/com/yetanalytics/datasim/onyx/dev_peer.clj
@@ -14,7 +14,7 @@
   [& args]
   ;; VERY MUCH JUST DEV RIGHT NOW
   (let [;; DEV ENV config, should go away for prod things
-        id (java.util.UUID/randomUUID)
+        id (random-uuid)
         {:keys [env-config peer-config]
          {:keys [n-vpeers]} :launch-config} (-> (config/get-config)
                                              (assoc-in [:env-config :onyx/tenancy-id] id)

--- a/src/dev_onyx/com/yetanalytics/datasim/onyx/scratch.clj
+++ b/src/dev_onyx/com/yetanalytics/datasim/onyx/scratch.clj
@@ -14,7 +14,7 @@
 
 (comment
   ;; Run things in an enclosed environment
-  (let [id (java.util.UUID/randomUUID)
+  (let [id (random-uuid)
         {:keys [env-config peer-config]} (-> (config/get-config)
                                              (assoc-in [:env-config :onyx/tenancy-id] id)
                                              (assoc-in [:peer-config :onyx/tenancy-id] id))]

--- a/src/main/com/yetanalytics/datasim.clj
+++ b/src/main/com/yetanalytics/datasim.clj
@@ -15,29 +15,31 @@
 
 ;; TODO: Add fdefs for generation functions
 ;; TODO: Extract more implementation code from `sim` namespace
-;; TODO: Use more opt-map passing (instead of `apply`) in Clojure 1.11
 
+#_{:clj-kondo/ignore [:unused-binding]}
 (defn generate-seq
   "Given `input`, produce a lazy sequence of statements in a synchronous
    fashion."
-  [input & kwargs]
-  (apply sim/sim-seq input kwargs))
+  [input & {:keys [select-agents] :as kwargs}]
+  (sim/sim-seq input kwargs))
 
 (defn generate-map
   "Given `input`, produce a map from actor IFIs to lazy sequences of statements
    that use those actors, all in a synchronous fashion."
-  [input & kwargs]
-  (apply sim/build-skeleton input kwargs))
+  [input]
+  (sim/build-skeleton input))
 
+#_{:clj-kondo/ignore [:unused-binding]}
 (defn generate-seq-async
   "Given `input`, produce a `core.async` channels that contains a generated
    sequence of simulated statements; this is for parallel generation."
-  [input & kwargs]
-  (apply sim/sim-chan input kwargs))
+  [input & {:keys [select-agents pad-chan-max] :as kwargs}]
+  (sim/sim-chan input kwargs))
 
+#_{:clj-kondo/ignore [:unused-binding]}
 (defn generate-map-async
   "Given `input`, produce a map from actor IFIs to `core.async` channels,
    each with their own generated sequence of simulated statements; this
    is for parallel generation."
-  [input & kwargs]
-  (apply sim/sim-chans input kwargs))
+  [input & {:keys [select-agents pad-chan-max sort buffer-size] :as kwargs}]
+  (sim/sim-chans input kwargs))

--- a/src/main/com/yetanalytics/datasim/math/random.clj
+++ b/src/main/com/yetanalytics/datasim/math/random.clj
@@ -3,7 +3,8 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as sgen]
             [com.yetanalytics.datasim.util.maths :as maths])
-  (:refer-clojure :exclude [rand rand-int rand-nth random-sample shuffle])
+  (:refer-clojure :exclude
+                  [rand rand-int rand-nth random-sample random-uuid shuffle])
   (:import [java.util UUID Random]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/main/com/yetanalytics/datasim/sim.clj
+++ b/src/main/com/yetanalytics/datasim/sim.clj
@@ -422,9 +422,7 @@
       :or {sort true
            buffer-size 100}
       :as kwargs}]
-  (let [chan-map (apply sim-chans
-                        input
-                        (mapcat identity kwargs))
+  (let [chan-map (sim-chans input kwargs)
         chans    (vals chan-map)]
     (if sort
       (->> chans

--- a/src/main/com/yetanalytics/datasim/sim.clj
+++ b/src/main/com/yetanalytics/datasim/sim.clj
@@ -382,21 +382,18 @@
    & {:keys [select-agents
              pad-chan-max]
       :or {pad-chan-max 1}}]
-  (let [skeleton (cond-> (build-skeleton input)
-                   select-agents
-                   (select-keys select-agents))
-        ?take-n  (when ?max-statements ; TODO: Handle division by zero error
-                   (->> (count skeleton)
-                        (quot ?max-statements)
-                        (+ pad-chan-max)))]
-    ;; TODO: Use reduce-vals after updating to Clojure 1.11
-    (reduce-kv
-     (fn [m k agent-seq]
-       (assoc m k (cond->> (a/to-chan! agent-seq)
-                    ?take-n
-                    (a/take ?take-n))))
-     (empty skeleton)
-     skeleton)))
+  (let [skeleton  (cond-> (build-skeleton input)
+                    select-agents
+                    (select-keys select-agents))
+        ?take-n   (when ?max-statements ; TODO: Handle division by zero error
+                    (->> (count skeleton)
+                         (quot ?max-statements)
+                         (+ pad-chan-max)))
+        seq->chan (fn [agent-seq]
+                    (cond->> (a/to-chan! agent-seq)
+                      ?take-n
+                      (a/take ?take-n)))]
+    (update-vals skeleton seq->chan)))
 
 ;; simulate single channel
 

--- a/src/main/com/yetanalytics/datasim/xapi/profile/activity.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/activity.clj
@@ -4,8 +4,9 @@
             [clojure.string     :as cs]
             [clojure.walk       :as w]
             [xapi-schema.spec   :as xs]
-            [com.yetanalytics.datasim.math.random :as random]
-            [com.yetanalytics.datasim.xapi.profile.template :as t]))
+            [com.yetanalytics.datasim.math.random           :as random]
+            [com.yetanalytics.datasim.xapi.profile          :as-alias profile]
+            [com.yetanalytics.datasim.xapi.profile.template :as template]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Specs
@@ -56,7 +57,7 @@
   "Derive Activity Type IDs from the Template's Rules"
   [template]
   (->> template
-       t/template->parsed-rules
+       template/template->parsed-rules
        rules->activity-type-ids))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -118,9 +119,8 @@
 ;; Putting it all together
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: Bring in type-iri-map spec using :as-alias in Clojure 1.11
 (s/fdef create-activity-map
-  :args (s/cat :type-iri-map map?
+  :args (s/cat :type-iri-map ::profile/type-iri-map
                :seed int?
                :kwargs (s/keys* :opt-un [::min-per-type]))
   :ret ::activity-map)

--- a/src/main/com/yetanalytics/datasim/xapi/profile/extension.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/extension.clj
@@ -1,7 +1,8 @@
 (ns com.yetanalytics.datasim.xapi.profile.extension
   "Creation of `extension-spec-map` for Profile compilation."
   (:require [clojure.spec.alpha       :as s]
-            [com.yetanalytics.schemer :as schemer]))
+            [com.yetanalytics.schemer :as schemer]
+            [com.yetanalytics.datasim.xapi.profile :as-alias profile]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Specs
@@ -18,9 +19,8 @@
 ;; Functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: Bring in type-iri-map spec using :as-alias in Clojure 1.11
 (s/fdef create-extension-spec-map
-  :args (s/cat :type-iri-map map?)
+  :args (s/cat :type-iri-map ::profile/type-iri-map)
   :ret ::extension-spec-map)
 
 (defn create-extension-spec-map

--- a/src/main/com/yetanalytics/datasim/xapi/profile/extension.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/extension.clj
@@ -25,13 +25,13 @@
 
 (defn create-extension-spec-map
   [type-iri-map]
-  (let [ext->spec   #(some->> % :inlineSchema (schemer/schema->spec nil))
-        reduce-ext  (partial reduce-kv
-                             (fn [m id ext] (assoc m id (ext->spec ext)))
-                             {})
+  (let [ext->spec   (fn [ext]
+                      (some->> ext :inlineSchema (schemer/schema->spec nil)))
+        reduce-exts (fn [ext-map]
+                      (update-vals ext-map ext->spec))
         act-iri-map (get type-iri-map "ActivityExtension")
         ctx-iri-map (get type-iri-map "ContextExtension")
         res-iri-map (get type-iri-map "ResultExtension")]
-    {:activity (reduce-ext act-iri-map)
-     :context  (reduce-ext ctx-iri-map)
-     :result   (reduce-ext res-iri-map)}))
+    {:activity (reduce-exts act-iri-map)
+     :context  (reduce-exts ctx-iri-map)
+     :result   (reduce-exts res-iri-map)}))

--- a/src/main/com/yetanalytics/datasim/xapi/profile/pattern.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/pattern.clj
@@ -5,7 +5,8 @@
             [com.yetanalytics.pan.objects.template     :as template]
             [com.yetanalytics.pan.objects.pattern      :as pattern]
             [com.yetanalytics.datasim.input.alignments :as alignment]
-            [com.yetanalytics.datasim.math.random      :as random]))
+            [com.yetanalytics.datasim.math.random      :as random]
+            [com.yetanalytics.datasim.xapi.profile     :as-alias profile]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Specs
@@ -94,9 +95,8 @@
        (filter z/node) ; empty seq nodes will be `nil`, so filter them out
        (keep (partial pattern-loc->template (meta pattern-zip)))))
 
-;; TODO: Bring in type-iri-map spec using :as-alias in Clojure 1.11
 (s/fdef create-pattern-walk-fn
-  :args (s/cat :type-iri-map map?)
+  :args (s/cat :type-iri-map ::profile/type-iri-map)
   :ret ::pattern-walk-fn)
 
 (defn create-pattern-walk-fn

--- a/src/main/com/yetanalytics/datasim/xapi/profile/template.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/template.clj
@@ -3,7 +3,8 @@
    compilation."
   (:require [clojure.spec.alpha :as s]
             [com.yetanalytics.pan.objects.template :as template]
-            [com.yetanalytics.datasim.xapi.rule    :as rule]))
+            [com.yetanalytics.datasim.xapi.rule    :as rule]
+            [com.yetanalytics.datasim.xapi.profile :as-alias profile]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Specs
@@ -102,11 +103,8 @@
 ;; Profile Templates -> Statement Base + Parsed Rules
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; TODO: Bring in type-iri-map and profile-map specs using :as-alias
-;; in Clojure 1.11
-
 (s/fdef create-statement-base-map
-  :args (s/cat :type-iri-map map?)
+  :args (s/cat :type-iri-map ::profile/type-iri-map)
   :ret ::statement-base-map)
 
 (defn create-statement-base-map
@@ -119,7 +117,7 @@
       (update-vals template->statement-base)))
 
 (s/fdef create-parsed-rules-map
-  :args (s/cat :type-iri-map? map?)
+  :args (s/cat :type-iri-map? ::profile/type-iri-map)
   :ret ::parsed-rules-map)
 
 (defn create-parsed-rules-map
@@ -131,7 +129,7 @@
       (update-vals template->parsed-rules)))
 
 (s/fdef update-parsed-rules-map
-  :args (s/cat :profile-map map?
+  :args (s/cat :profile-map ::profile/profile-map
                :parsed-rules-map ::parsed-rules-map)
   :ret ::parsed-rules-map)
 

--- a/src/main/com/yetanalytics/datasim/xapi/profile/template.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/template.clj
@@ -114,12 +114,9 @@
    templates' IDs to the base xAPI Statements they form from their
    Determining Properties and inScheme."
   [type-iri-map]
-  (->> (get type-iri-map "StatementTemplate")
-       (reduce-kv (fn [m id template]
-                    (->> template
-                         template->statement-base
-                         (assoc m id)))
-                  {})))
+  (-> type-iri-map
+      (get "StatementTemplate")
+      (update-vals template->statement-base)))
 
 (s/fdef create-parsed-rules-map
   :args (s/cat :type-iri-map? map?)
@@ -129,13 +126,9 @@
   "Given Statement Templates in `type-iri-map`, return a map from those
    templates' IDs to those their parsed rules"
   [type-iri-map]
-  ;; TODO: Use map-values in Clojure 1.11
-  (->> (get type-iri-map "StatementTemplate")
-       (reduce-kv (fn [m id template]
-                    (->> template
-                         template->parsed-rules
-                         (assoc m id)))
-                  {})))
+  (-> type-iri-map
+      (get "StatementTemplate")
+      (update-vals template->parsed-rules)))
 
 (s/fdef update-parsed-rules-map
   :args (s/cat :profile-map map?
@@ -146,9 +139,5 @@
   "Use information from `profile-map` to complete the rules in
    `parsed-rules-map` by adding additional valuesets or spec generators."
   [profile-map parsed-rules-map]
-  (reduce-kv (fn [m template-id parsed-rules]
-               (->> parsed-rules
-                    (rule/add-rules-valuegen profile-map)
-                    (assoc m template-id)))
-             {}
-             parsed-rules-map))
+  (update-vals parsed-rules-map
+               (partial rule/add-rules-valuegen profile-map)))

--- a/src/main/com/yetanalytics/datasim/xapi/profile/verb.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/verb.clj
@@ -29,6 +29,4 @@
   "Create a map of verb IDs to Statement verbs out of Profile Verbs from
    `type-iri-map`."
   [type-iri-map]
-  (reduce-kv (fn [m id verb] (assoc m id (profile->statement-verb verb)))
-             {}
-             (get type-iri-map "Verb")))
+  (-> type-iri-map (get "Verb") (update-vals profile->statement-verb)))

--- a/src/main/com/yetanalytics/datasim/xapi/profile/verb.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/verb.clj
@@ -2,7 +2,8 @@
   "Creation of `verb-map` for Profile compilation."
   (:require [clojure.spec.alpha :as s]
             [clojure.walk       :as w]
-            [xapi-schema.spec   :as xs]))
+            [xapi-schema.spec   :as xs]
+            [com.yetanalytics.datasim.xapi.profile :as-alias profile]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Specs
@@ -20,9 +21,8 @@
   {"id"      id
    "display" (w/stringify-keys prefLabel)})
 
-;; TODO: Bring in type-iri-map spec using :as-alias in Clojure 1.11
 (s/fdef create-verb-map
-  :args (s/cat :type-iri-map map?)
+  :args (s/cat :type-iri-map ::profile/type-iri-map)
   :ret ::verb-map)
 
 (defn create-verb-map

--- a/src/main/com/yetanalytics/datasim/xapi/rule.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/rule.clj
@@ -14,7 +14,8 @@
             [com.yetanalytics.pathetic.path :as jpath]
             [com.yetanalytics.pan.objects.templates.rule :as rule]
             [com.yetanalytics.datasim.xapi.path          :as xp]
-            [com.yetanalytics.datasim.math.random        :as random]))
+            [com.yetanalytics.datasim.math.random        :as random]
+            [com.yetanalytics.datasim.xapi.profile       :as-alias profile]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Specs
@@ -354,9 +355,8 @@
              (not ?all-set))
         (assoc :generator (spec-generator spec*))))))
 
-;; TODO: Bring in profile-map spec using :as-alias in Clojure 1.11
 (s/fdef add-rules-valuegen
-  :args (s/cat :profile-map  map?
+  :args (s/cat :profile-map  ::profile/profile-map
                :parsed-rules ::parsed-rules)
   :ret ::parsed-rules)
 

--- a/src/onyx/com/yetanalytics/datasim/onyx/main.clj
+++ b/src/onyx/com/yetanalytics/datasim/onyx/main.clj
@@ -22,46 +22,60 @@
             )
   (:import [java.net InetAddress]))
 
+;; TODO: More variations, e.g. positive ints only
+(def ^:private validate-int
+  [int? "Not an integer."])
+
 (def cli-options
   [;; Peer
    ["-n" "--n-vpeers N_VPEERS" "Number of VPEERS to launch. Overrides config value."
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
    ;; Peer + Submit
    ["-t" "--tenancy-id TENANCY_ID" "Onyx Tenancy ID"]
    ;; Submit
    ;; sim
    ["-i" "--input-loc INPUT_LOC" "DATASIM input location"]
    ["-m" "--override-max OVERRIDE_MAX" "Override max statements"
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
    ;; Gen overrides
    [nil "--[no-]strip-ids" "Strip IDs from generated statements" :default false]
    [nil "--[no-]remove-refs" "Filter out statement references" :default false]
 
    ["-c" "--gen-concurrency GEN_CONCURRENCY" "Desired concurrency of generation."
     :default 1
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
    ["-b" "--gen-batch-size GEN_BATCH_SIZE" "Generate this number of statements at a time."
     :default 1000
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
    ["-r" "--out-ratio OUT_RATIO" "Ratio of inputs to outputs, defaults to 8"
     :default 1
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
    [nil "--percentage PERCENTAGE" "Percentage of cluster to utilize"
     :default 100
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
 
    [nil "--in-batch-size IN_BATCH_SIZE" "Onyx input batch size"
     :default 1
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
    [nil "--in-batch-timeout IN_BATCH_TIMEOUT" "Input batch timeout"
     :default 50
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
    [nil "--out-batch-size OUT_BATCH_SIZE" "Batch Size of Output"
     :default 1
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
    [nil "--out-batch-timeout OUT_BATCH_TIMEOUT" "Output batch timeout"
     :default 50
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
 
    [nil "--out-mode OUT_MODE" "Output type, LRS or S3"
     :parse-fn keyword
@@ -77,13 +91,16 @@
    [nil "--lrs-x-api-key X_API_KEY" "AWS API Gateway API key (optional)"]
    [nil "--lrs-retry-base-sleep-ms RETRY_BASE_SLEEP_MS" "Backoff retry sleep time"
     :default 500 ;; real cool about it
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
    [nil "--lrs-retry-max-sleep-ms RETRY_MAX_SLEEP_MS" "Backoff retry sleep time max per retry."
     :default 30000 ;; every 30 sec max
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
    [nil "--lrs-retry-max-total-sleep-ms RETRY_MAX_TOTAL_SLEEP_MS" "Backoff retry sleep time max total."
     :default 3600000 ;; an hour, why not
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
 
    ;; S3 OUT
    [nil "--s3-bucket S3_BUCKET" "S3 out bucket"]
@@ -96,7 +113,8 @@
     :default :none]
    [nil "--s3-max-concurrent-uploads S3_MAX_CONCURRENT_UPLOADS" "S3 Max concurrent uploads per peer"
     :default 16 ;; For a sim with conc of 64 this can easily overload s3 and get a 503
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
 
 
    ;; Blocking (a little hard to predict)
@@ -106,7 +124,8 @@
    [nil "--nrepl-bind NREPL_BIND" "If provided on peer launch will start an nrepl server bound to this address"
     :default "0.0.0.0"]
    [nil "--nrepl-port NREPL_PORT" "If provided on peer launch will start an nrepl server on this port"
-    :parse-fn #(Integer/parseInt %)]
+    :parse-fn parse-long
+    :validate validate-int]
    ["-h" "--help"]])
 
 (defn usage [options-summary]

--- a/src/onyx/com/yetanalytics/datasim/onyx/sim.clj
+++ b/src/onyx/com/yetanalytics/datasim/onyx/sim.clj
@@ -19,12 +19,9 @@
    task-prefix
    ]
   (lazy-seq
-   (cond->> (if select-agents
-              (ds/generate-seq
-               input
-               :select-agents select-agents)
-              (ds/generate-seq
-               input))
+   (cond->> (ds/generate-seq
+             input
+             (cond-> {} select-agents (assoc :select-agents select-agents)))
      take-n (take take-n)
      drop-n (drop (* drop-n batch-size))
      strip-ids?

--- a/src/onyx/com/yetanalytics/datasim/onyx/sim.clj
+++ b/src/onyx/com/yetanalytics/datasim/onyx/sim.clj
@@ -169,7 +169,7 @@
                   :batch-size nil}
        :onyx.core/task :out-0
        :onyx.core/tenancy-id "foo"
-       :onyx.core/job-id (java.util.UUID/randomUUID)})
+       :onyx.core/job-id (random-uuid)})
      nil nil
      ))
 
@@ -187,7 +187,7 @@
                             }
                  :onyx.core/task :out-0
                  :onyx.core/tenancy-id "foo"
-                 :onyx.core/job-id (java.util.UUID/randomUUID)})]
+                 :onyx.core/job-id (random-uuid)})]
     (p/recover! reader nil nil)
     (time
      (dotimes [n 10000]

--- a/src/server/com/yetanalytics/datasim/server.clj
+++ b/src/server/com/yetanalytics/datasim/server.clj
@@ -64,7 +64,7 @@
   ;; Read in each part of the input file, and convert into EDN
   (let [sim-input      (sim-input input)
         send-to-lrs    (if-some [send-to-lrs (get input "send-to-lrs")]
-                         (read-string send-to-lrs)
+                         (parse-boolean send-to-lrs)
                          false)
         endpoint       (get input "lrs-endpoint")
         api-key        (get input "api-key")


### PR DESCRIPTION
Use features introduced in Clojure 1.11, such as kwarg map passing, `update-vals`, `:as-alias`, and new parse functions.