### PR TITLE
Fix exception that happens if no Verb or Activity concepts exist

### DIFF
--- a/dev-resources/profiles/no_concept.jsonld
+++ b/dev-resources/profiles/no_concept.jsonld
@@ -1,0 +1,58 @@
+{
+	"id": "https://www.example.com/xapi/profile",
+	"conformsTo": "https://w3id.org/xapi/profiles#1.0",
+	"versions": [
+		{
+			"id": "https://example.com/xapi/profile/v1.0.0",
+			"generatedAtTime": "2022-11-15T16:35:26.240428Z"
+		}
+	],
+	"@context": "https://w3id.org/xapi/profiles/context",
+	"definition": {
+		"en": "Test Profile with no Verbs, Activities, or other Concepts"
+	},
+	"prefLabel": {
+		"en": "Test Profile"
+	},
+	"type": "Profile",
+	"author": {
+		"type": "Organization",
+		"name": "Yet Analytics"
+	},
+	"templates": [
+		{
+			"definition": {
+				"en": "Test Template"
+			},
+			"prefLabel": {
+				"en": "Test Template"
+			},
+			"type": "StatementTemplate",
+			"rules": [
+				{
+					"location": "$.object.id",
+					"presence": "included"
+				}
+			],
+			"inScheme": "https://example.com/xapi/profile/v1.0.0",
+			"id": "https://example.com/xapi/profile/template"
+		}
+	],
+	"patterns": [
+		{
+			"definition": {
+				"en": "Test Pattern"
+			},
+			"primary": true,
+			"prefLabel": {
+				"en": "Test Pattern"
+			},
+			"type": "Pattern",
+			"inScheme": "https://example.com/xapi/profile/v1.0.0",
+			"id": "https://example.com/xapi/profile/pattern",
+			"sequence": [
+				"https://example.com/xapi/profile/template"
+			]
+		}
+	]
+}

--- a/src/main/com/yetanalytics/datasim/xapi/statement/healing.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/statement/healing.clj
@@ -89,7 +89,11 @@
               merge-verb)
      ;; Choose random verb
      (some->> verb-map
-              (random/choose-map rng alignment)))))
+              not-empty
+              (random/choose-map rng alignment))
+     ;; Generate random verb
+     (some->> {}
+              (generate-verb rng)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Activities
@@ -121,6 +125,7 @@
      ;; Get activity by type
      (some->> type
               (get activity-map)
+              not-empty
               (random/choose-map rng alignment)
               merge-activity)
      ;; Activity w/ ID not found, return as-is
@@ -132,8 +137,12 @@
               merge-activity)
      ;; Choose random activity
      (some->> activity-map
+              not-empty
               (random/choose-map rng alignment)
-              (random/choose-map rng alignment)))))
+              (random/choose-map rng alignment))
+     ;; Generate random activity
+     (some->> {}
+              (generate-activity rng)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Agents

--- a/src/main/com/yetanalytics/datasim/xapi/statement/healing.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/statement/healing.clj
@@ -72,16 +72,16 @@
   :ret ::xs/verb)
 
 (defn complete-verb
-  [{:strs [id] :as verb} {:keys [verb-map alignment]} rng]
+  [{verb-id "id" :as verb} {:keys [verb-map alignment]} rng]
   (let [return-verb (fn [_] verb)
         merge-verb  (fn [v] (merge-nested v verb))]
     (or
      ;; Verb found by ID
-     (some->> id
+     (some->> verb-id
               verb-map
               merge-verb)
      ;; Verb w/ ID not found, return as-is
-     (some->> id
+     (some->> verb-id
               return-verb)
      ;; Verb w/o ID not found, generate ID
      (some->> verb
@@ -91,7 +91,7 @@
      (some->> verb-map
               not-empty
               (random/choose-map rng alignment))
-     ;; Generate random verb
+     ;; Generate random verb as verb map is empty
      (some->> {}
               (generate-verb rng)))))
 
@@ -112,24 +112,24 @@
   :ret ::xs/activity)
 
 (defn complete-activity
-  [{:strs [id] {:strs [type]} "definition" :as activity}
+  [{activity-id "id" {activity-type "type"} "definition" :as activity}
    {:keys [activity-map alignment]}
    rng]
   (let [return-activity (fn [_] activity)
         merge-activity  (fn [a] (merge-nested a activity))]
     (or
      ;; Get activity by ID
-     (some->> id
+     (some->> activity-id
               (get (reduce merge {} (vals activity-map)))
               merge-activity)
      ;; Get activity by type
-     (some->> type
+     (some->> activity-type
               (get activity-map)
               not-empty
               (random/choose-map rng alignment)
               merge-activity)
      ;; Activity w/ ID not found, return as-is
-     (some->> id
+     (some->> activity-id
               return-activity)
      ;; Activity w/o ID not found, assoc generated
      (some->> activity
@@ -140,7 +140,7 @@
               not-empty
               (random/choose-map rng alignment)
               (random/choose-map rng alignment))
-     ;; Generate random activity
+     ;; Generate random activity as activity map is empty
      (some->> {}
               (generate-activity rng)))))
 

--- a/src/test/com/yetanalytics/datasim/test_constants.clj
+++ b/src/test/com/yetanalytics/datasim/test_constants.clj
@@ -11,6 +11,8 @@
 
 (def minimal-profile-filepath
   "dev-resources/profiles/minimal.jsonld")
+(def no-concept-profile-filepath
+  "dev-resources/profiles/no_concept.jsonld")
 (def cmi5-profile-filepath
   "dev-resources/profiles/cmi5/fixed.json")
 (def video-profile-filepath
@@ -75,6 +77,9 @@
 
 (def minimal-profile
   (input/from-location :profile :json minimal-profile-filepath))
+
+(def no-concept-profile
+  (input/from-location :profile :json no-concept-profile-filepath))
 
 (def cmi5-profile
   (input/from-location :profile :json cmi5-profile-filepath))

--- a/src/test/com/yetanalytics/datasim_test.clj
+++ b/src/test/com/yetanalytics/datasim_test.clj
@@ -71,6 +71,9 @@
 (def double-profile-input
   (update const/simple-input :profiles conj const/mom-profile))
 
+(def no-concepts-profile-input
+  (assoc const/simple-input :profiles [const/no-concept-profile]))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -78,6 +81,8 @@
 (deftest generate-map-test
   (testing "Given valid input, returns a valid skeleton"
     (is (s/valid? ::sim/skeleton (generate-map const/simple-input))))
+  (testing "Profiles w/o concepts count as valid input"
+    (is (s/valid? ::sim/skeleton (generate-map no-concepts-profile-input))))
   (testing "Make sure RNGs aren't shared across threads."
     (let [skeleton (generate-map (assoc-in const/simple-input
                                            [:parameters :end]
@@ -110,6 +115,8 @@
 (deftest generate-seq-test
   (testing "Returns statements"
     (is (s/valid? (s/every ::xs/statement) (generate-seq const/simple-input))))
+  (testing "Returns statements even without concepts"
+    (is (s/valid? (s/every ::xs/statement) (generate-seq no-concepts-profile-input))))
   (testing "Respects `max` param"
     (let [ret (generate-seq (assoc-in const/simple-input [:parameters :max] 3))]
       (is (s/valid? (s/every ::xs/statement) ret))
@@ -153,7 +160,7 @@
                distinct))))
   (testing "Respects agent selection"
     (let [ret (generate-seq (assoc-in const/simple-input [:parameters :max] 3)
-                       ;; specify we only want the given agent(s)
+                            ;; specify we only want the given agent(s)
                             :select-agents [bob-mbox])]
       (is (every?
            #(= bob-mailto (get-actor-mbox %))


### PR DESCRIPTION
Fix a bug where whenever no Verbs or Activities exist to be chosen during statement healing, an exception is thrown by `random/choose-map`. Do so by performing spec generation whenever that case occurs, which @cliffcaseyyet had said is an acceptable fallback (in lieu of a fixed fallback value) since it will immediately tell the user that Verbs/Activities are not present.

Note that in Poseidon, this had happened before the major refactors for Activities, which resulted in a lot of fallback code being written.