### PR TITLE
[DS-150] Time period changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ and `weight` values (as described under `verbs`).
     - `mean` the average amount of time between Statements (added on top of `min`); default is `1`
     - `fixed`: a fixed amount of time between Statements; overrides `min` and `mean`
     - `unit`: the time unit for all temporal values. Valid values are `millis`, `seconds`, `minutes`, `hours`, `days`, and `weeks`; the default is `minutes`
-    - `bounds`: an array of the temporal bounds the period can apply in. During generation, the current Statement timestamp is checked against each period's `bounds`, and the first period whose bound satisfies the timestamp will be used to generate the next Statement timestamp. A missing `bounds` value indicates an infinite bound, i.e. any timestamp is always valid. The syntax is the same as the top-level `bounds` array.
+    - `bounds`: an array of the temporal bounds the period can apply in. During generation, the current Statement timestamp is checked against each period's `bounds`, and the first period whose bound satisfies the timestamp will be used to generate the next Statement timestamp. A nonexisting `bounds` value indicates an infinite bound, i.e. any timestamp is always valid. The syntax is the same as the top-level `bounds` array. At least one period must not have a `bounds` value, so it can act as the default period.
   - `retry`: One of four options that determine Statement generation retry behavior in the event where a time bound is exceeded:
     - `null` (or not present): Terminate the generation on the current Pattern immediately, and move again with the next Pattern's generation.
     - `"pattern"`: Retry generation of this Pattern if this Pattern's bound is exceeded.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ and `weight` values (as described under `verbs`).
 - `patterns`: An array of objects with Pattern `id` and the following additional optional values:
   - `weights`: An array of child Pattern/Template `id` and `weight` values. Each weight affects how likely each of the Pattern's child patterns are chosen (for `alternates`) or how likely the child Pattern will be selected at all (for `optional`, for these `null` is also a valid option). This has no effect on `sequence`, `zeroOrMore`, or `oneOrMore` Patterns.
   - `repeat-max`: A positive integer representing the maximum number of times (exclusive) the child pattern can be generated. Only affects `zeroOrMore` and `oneOrMore` patterns.
-  - `bounds`: An array of objects containing key-value pairs where each value is an array of singular values (e.g. `"January"`) or pair arrays of start and end values (e.g. `["January", "October"]`). For example `{"years": [2023], "months": [[1 5]]}` describes an inclusive bound from January to May 2023. The following are valid bound values:
+  - `bounds`: An array of objects containing key-value pairs where each value is an array of singular values (e.g. `"January"`) or pair arrays of start and end values (e.g. `["January", "October"]`). For example `{"years": [2023], "months": [[1 5]]}` describes an inclusive bound from January to May 2023. If not present, indicates an infinite bound, such that any timestamp is valid. The following are valid bound values:
     - `years`: Any positive integer
     - `months`: `1` to `12`, or their name equivalents, i.e. `"January"` to `"December"`
     - `daysOfMonth:` `1` to `31` (though `29` or `30` are skipped at runtime for months that do not include these days)
@@ -90,7 +90,12 @@ and `weight` values (as described under `verbs`).
     - `hours`: `0` to `23`
     - `minutes`: `0` to `59`
     - `seconds`: `0` to `59`
-  - `period`: an object with `mean`, `min`, and `unit` properties. `min` specifies a minimum delay, `mean` the average delay (added on top of `min`), and `unit` the time unit for both (valid values are `millis`, `seconds`, `minutes`, `hours`, `days`, and `weeks`). This only applies to Statement Templates and Patterns; child Patterns or Templates will override any `period` properties set by parent Patterns.
+  - `periods`: an array of objects that specify the amount of time between generated Statements. Only the first valid period in the array will be applied to generate the next Statement (see `bounds` property). Each period object has the following optional properties:
+    - `min`: a minimum amount of time between Statements; default is `0`
+    - `mean` the average amount of time between Statements (added on top of `min`); default is `1`
+    - `fixed`: a fixed amount of time between Statements; overrides `min` and `mean`
+    - `unit`: the time unit for all temporal values. Valid values are `millis`, `seconds`, `minutes`, `hours`, `days`, and `weeks`; the default is `minutes`
+    - `bounds`: an array of the temporal bounds the period can apply in. During generation, the current Statement timestamp is checked against each period's `bounds`, and the first period whose bound satisfies the timestamp will be used to generate the next Statement timestamp. A missing `bounds` value indicates an infinite bound, i.e. any timestamp is always valid. The syntax is the same as the top-level `bounds` array.
   - `retry`: One of four options that determine Statement generation retry behavior in the event where a time bound is exceeded:
     - `null` (or not present): Terminate the generation on the current Pattern immediately, and move again with the next Pattern's generation.
     - `"pattern"`: Retry generation of this Pattern if this Pattern's bound is exceeded.

--- a/dev-resources/models/simple_with_temporal.json
+++ b/dev-resources/models/simple_with_temporal.json
@@ -9,11 +9,13 @@
         "patterns": [
             {
                 "id": "https://w3id.org/xapi/cmi5#satisfieds",
-                "period": {
-                    "min": 1,
-                    "mean": 1.0,
-                    "unit": "hours"
-                }
+                "periods": [
+                    {
+                        "min": 1,
+                        "mean": 1.0,
+                        "unit": "hours"
+                    }
+                ]
             }
         ]
     },

--- a/dev-resources/models/simple_with_temporal.json
+++ b/dev-resources/models/simple_with_temporal.json
@@ -31,8 +31,7 @@
                 "id": "https://w3id.org/xapi/cmi5#typicalsessions",
                 "bounds": [
                     {
-                        "months": [["January", "October"], "December"],
-                        "years": [2019]
+                        "months": [["January", "October"], "December"]
                     }
                 ]
             }
@@ -42,7 +41,7 @@
                 "id": "https://w3id.org/xapi/cmi5#satisfied",
                 "bounds": [
                     {
-                        "minutes": [[0, 35], [50, 59]]
+                        "minutes": [[0, 10]]
                     }
                 ]
             }

--- a/src/main/com/yetanalytics/datasim/input/model/alignments.clj
+++ b/src/main/com/yetanalytics/datasim/input/model/alignments.clj
@@ -125,10 +125,12 @@
 (s/def ::period/unit
   #{"millis" "seconds" "minutes" "hours" "days" "weeks"})
 
-(s/def ::period
-  (s/keys :opt-un [::period/min
-                   ::period/mean
-                   ::period/unit]))
+(s/def ::periods
+  (s/every (s/keys :opt-un [::period/min
+                            ::period/mean
+                            ::period/unit])
+           :kind vector?
+           :min-count 1))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Retry Options
@@ -191,13 +193,13 @@
           :opt-un [::weights    ; for alternate and optional patterns 
                    ::repeat-max ; for oneOrMore and zeroOrMore patterns
                    ::bounds
-                   ::period
+                   ::periods
                    ::retry]))
 
 (def template-spec
   (s/keys :req-un [::id]
           :opt-un [::bounds
-                   ::period
+                   ::periods
                    ::retry]))
 
 (def object-override-spec

--- a/src/main/com/yetanalytics/datasim/input/model/alignments.clj
+++ b/src/main/com/yetanalytics/datasim/input/model/alignments.clj
@@ -125,10 +125,14 @@
 (s/def ::period/unit
   #{"millis" "seconds" "minutes" "hours" "days" "weeks"})
 
+(s/def ::period/bounds
+  ::bounds)
+
 (s/def ::periods
   (s/every (s/keys :opt-un [::period/min
                             ::period/mean
-                            ::period/unit])
+                            ::period/unit
+                            ::period/bounds])
            :kind vector?
            :min-count 1))
 

--- a/src/main/com/yetanalytics/datasim/input/model/alignments.clj
+++ b/src/main/com/yetanalytics/datasim/input/model/alignments.clj
@@ -122,6 +122,9 @@
 (s/def ::period/mean
   (s/and number? pos? (comp not zero?)))
 
+(s/def ::period/fixed
+  (s/and number? pos? (comp not zero?)))
+
 (s/def ::period/unit
   #{"millis" "seconds" "minutes" "hours" "days" "weeks"})
 
@@ -131,6 +134,7 @@
 (s/def ::periods
   (s/every (s/keys :opt-un [::period/min
                             ::period/mean
+                            ::period/fixed
                             ::period/unit
                             ::period/bounds])
            :kind vector?

--- a/src/main/com/yetanalytics/datasim/input/model/alignments.clj
+++ b/src/main/com/yetanalytics/datasim/input/model/alignments.clj
@@ -116,6 +116,11 @@
 ;; Time Period
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn- has-default-period?
+  [periods]
+  (some (fn [{:keys [bounds] :as period}] (when (not bounds) period))
+        periods))
+
 (s/def ::period/min
   (s/and number? pos?))
 
@@ -137,7 +142,7 @@
                             ::period/fixed
                             ::period/unit
                             ::period/bounds])
-           :kind vector?
+           :kind (every-pred vector? has-default-period?)
            :min-count 1))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/main/com/yetanalytics/datasim/model.clj
+++ b/src/main/com/yetanalytics/datasim/model.clj
@@ -96,12 +96,12 @@
 (defn- reduce-patterns
   [patterns]
   (reduce
-   (fn [acc {:keys [id weights repeat-max bounds period retry]}]
+   (fn [acc {:keys [id weights repeat-max bounds periods retry]}]
      (let [m (cond-> {}
                weights    (assoc :weights (reduce-weights weights))
-               bounds     (assoc :bounds (temporal/convert-bounds bounds))
-               period     (assoc :period (temporal/convert-period period))
-               retry      (assoc :retry (keyword retry))
+               bounds     (assoc :bounds  (temporal/convert-bounds bounds))
+               periods    (assoc :periods (temporal/convert-periods periods))
+               retry      (assoc :retry   (keyword retry))
                repeat-max (assoc :repeat-max repeat-max))]
        (assoc acc id m)))
    {}

--- a/src/main/com/yetanalytics/datasim/model/temporal.clj
+++ b/src/main/com/yetanalytics/datasim/model/temporal.clj
@@ -24,9 +24,7 @@
 
 (s/def ::month (s/int-in 1 13))
 
-(s/def ::day (s/int-in 1 32))
-
-(s/def ::day-of-month ::day)
+(s/def ::day-of-month (s/int-in 1 32))
 
 (s/def ::day-of-week (s/int-in 0 6))
 
@@ -41,9 +39,6 @@
 
 (s/def ::months
   (s/coll-of ::month :distinct true :min-count 1))
-
-(s/def ::days
-  (s/coll-of ::day :distinct true :min-count 1))
 
 (s/def ::days-of-month
   (s/coll-of ::day-of-month :distinct true :min-count 1))
@@ -60,21 +55,7 @@
 (s/def ::seconds
   (s/coll-of ::second :distinct true :min-count 1))
 
-(def ^:private ranges-spec
-  (s/keys :opt-un [::years
-                   ::months
-                   ::days
-                   ::hours
-                   ::minutes
-                   ::seconds]))
-
-(s/def ::ranges
-  (s/with-gen (s/and ranges-spec
-                     (s/map-of keyword? (s/and seq? sorted-entries?)))
-    (fn [] (sgen/fmap #(update-vals % sort)
-                      (s/gen ranges-spec)))))
-
-(def ^:private sets-spec
+(def ^:private bound-spec
   (s/keys :opt-un [::years
                    ::months
                    ::days-of-month
@@ -83,21 +64,32 @@
                    ::minutes
                    ::seconds]))
 
+(s/def ::ranges
+  (s/with-gen (s/and bound-spec
+                     (s/map-of keyword? (s/and seq? sorted-entries?)))
+    (fn [] (sgen/fmap #(update-vals % sort)
+                      (s/gen bound-spec)))))
+
 (s/def ::sets
-  (s/with-gen (s/and sets-spec
+  (s/with-gen (s/and bound-spec
                      (s/map-of keyword? set?))
     (fn [] (sgen/fmap #(update-vals % set)
-                      (s/gen sets-spec)))))
+                      (s/gen bound-spec)))))
 
 (s/def ::bounds
-  (s/keys :req-un [::ranges ::sets]))
+  (s/every (s/keys :req-un [::ranges ::sets])))
 
 (s/def ::min nat-int?)
 
 (s/def ::mean pos-int?)
 
+(s/def ::fixed pos-int?)
+
 (s/def ::period
-  (s/keys :req-un [::min ::mean]))
+  (s/or :variable (s/keys :req-un [::min ::mean]
+                          :opt-un [::bounds])
+        :fixed (s/keys :req-un [::fixed]
+                       :opt-un [::bounds])))
 
 (s/def ::periods
   (s/every ::period))
@@ -134,7 +126,7 @@
     {:year         year
      :month        month
      :day-of-month day-month
-     :day-of-week  day-week
+     :day-of-week  (mod day-week 7) ; need to convert Sunday from 7 to 0
      :hour         hour
      :minute       minute
      :second       second}))
@@ -153,7 +145,7 @@
 (s/fdef day-of-month?
   :args (s/cat :year  ::year
                :month ::month
-               :day   ::day)
+               :day   ::day-of-month)
   :ret boolean?)
 
 (defn day-of-month?
@@ -190,7 +182,7 @@
 (s/fdef day-of-week
   :args (s/cat :year  ::year
                :month ::month
-               :day   ::day)
+               :day   ::day-of-month)
   :ret ::day-of-week)
 
 (defn day-of-week
@@ -226,7 +218,7 @@
   [unit]
   (case unit
     :daysOfWeek  :days-of-week
-    :daysOfMonth :day-of-month
+    :daysOfMonth :days-of-month
     unit))
 
 (defn- reduce-values
@@ -295,15 +287,16 @@
 
 (defn- convert-period
   [{:keys [min mean fixed unit bounds]}]
-  (let [unit*   (or (some-> unit keyword) :minute)
+  (let [unit*   (or (some-> unit keyword) :minutes)
         mean*   (or (some-> mean (convert-time unit*)) ms-per-minute)
         min*    (or (some-> min (convert-time unit*)) 0)
         fixed*  (some-> fixed (convert-time unit*))
         bounds* (some-> bounds convert-bounds)]
-    {:min    min*
-     :mean   mean*
-     :fixed  fixed*
-     :bounds bounds*}))
+    (cond-> {}
+      fixed*       (assoc :fixed fixed*)
+      (not fixed*) (assoc :min min*
+                          :mean mean*)
+      bounds*      (assoc :bounds bounds*))))
 
 (s/fdef convert-periods
   :args (s/cat :periods ::align/periods)
@@ -325,16 +318,17 @@
       (contains? unit-set unit)))
 
 (defn- in-bound?
-  [{{:keys [years months days-of-month days-of-week hours minutes]} :sets}
+  [{{:keys [years months days-of-month days-of-week hours minutes seconds]} :sets}
    date-time]
-  (let [{:keys [year month day-of-month day-of-week hour minute]}
+  (let [{:keys [year month day-of-month day-of-week hour minute second]}
         (time-map date-time)]
     (and (in-bound-unit? years year)
          (in-bound-unit? months month)
          (in-bound-unit? days-of-month day-of-month)
          (in-bound-unit? days-of-week day-of-week)
          (in-bound-unit? hours hour)
-         (in-bound-unit? minutes minute))))
+         (in-bound-unit? minutes minute)
+         (in-bound-unit? seconds second))))
 
 (s/fdef bounded-time?
   :args (s/cat :bounds    ::bounds
@@ -362,7 +356,7 @@
            (< inst-time t))))
 
 (defn- next-bounded-times
-  "Returns a sequence of the next LocalDateTime that are within `bounds`."
+  "Returns a sequence of the next LocalDateTime that are within the bound."
   [{{:keys [years months days-of-month hours minutes seconds]
      :or {months        (range 1 13)
           days-of-month (range 1 32)
@@ -380,6 +374,9 @@
          inst-min :minute
          inst-sec :second}
         (time-map date-time)
+        years
+        (or years
+            (range inst-yr Integer/MAX_VALUE))
         day-of-week?
         (if (empty? days-of-week)
           (constantly true)
@@ -426,17 +423,16 @@
   :ret ::date-time)
 
 (defn next-bounded-time
+  "Returns the next timestamp after `date-time` within any of the `bounds`."
   [bounds date-time]
-  (first (next-bounded-times bounds date-time)))
+  (some (fn [bound]
+          (first (next-bounded-times bound date-time)))
+        bounds))
 
 ;; Next Time
 
-(def min-ms 60000.0) ; The amount of milliseconds in one minute
-
 (defn- generate-period
-  [rng {:keys [mean min fixed]
-        :or {mean min-ms
-             min  0}}]
+  [rng {:keys [mean min fixed]}]
   (or fixed
       (let [rate   (/ 1.0 mean)
             t-diff (long (random/rand-exp rng rate))]
@@ -460,7 +456,10 @@
    The generated sequence that uses these periodic date-times will thus occur
    as a Poisson random process."
   [date-time rng periods]
-  (let [some-bound (fn [{:keys [bounds] :as period}]
+  (let [periods    (or periods
+                       [{:min  0
+                         :mean ms-per-minute}])
+        some-bound (fn [{:keys [bounds] :as period}]
                      (when (bounded-time? bounds date-time) period))]
     (if-some [period (some some-bound periods)]
       (add-period date-time rng period)
@@ -468,23 +467,3 @@
                       {:type      ::outside-period-bound
                        :periods   periods
                        :date-time date-time})))))
-
-(comment
-  (def the-time (t/local-date-time (t/instant) "UTC"))
-  (def the-rng (random/seed-rng 100))
-  (def converted-periods
-    (convert-periods
-     [{:fixed 1
-       :unit "hours"
-       :bounds [{:years [2020 #_2023]}]}
-      {:min 1
-       :unit "seconds"}]))
-  
-  (bounded-time? (get-in converted-periods [0 :bounds])
-                 the-time)
-  
-  the-time
-  (add-periods the-time
-               the-rng
-               converted-periods)
-  )

--- a/src/main/com/yetanalytics/datasim/model/temporal.clj
+++ b/src/main/com/yetanalytics/datasim/model/temporal.clj
@@ -462,9 +462,12 @@
   [date-time rng periods]
   (let [some-bound (fn [{:keys [bounds] :as period}]
                      (when (bounded-time? bounds date-time) period))]
-    (->> periods
-         (some some-bound)
-         (add-period date-time rng))))
+    (if-some [period (some some-bound periods)]
+      (add-period date-time rng period)
+      (throw (ex-info "Timestamp does not satisfy any period `bounds`; no default period present."
+                      {:type      ::outside-period-bound
+                       :periods   periods
+                       :date-time date-time})))))
 
 (comment
   (def the-time (t/local-date-time (t/instant) "UTC"))

--- a/src/main/com/yetanalytics/datasim/xapi/profile/pattern.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/pattern.clj
@@ -188,11 +188,11 @@
 
 (defn- visit-template
   [{:keys [rng] :as ctx}
-   {:keys [period bounds retry retry-id] :as alignments}
+   {:keys [periods bounds retry retry-id] :as alignments}
    prev-timestamp
    prev-timestamp-gen
    template]
-  (let [timestamp (temporal/add-period prev-timestamp rng period)]
+  (let [timestamp (temporal/add-periods prev-timestamp rng periods)]
     (if (temporal/bounded-time? bounds timestamp)
       (with-meta (list {:template        template
                         :timestamp       timestamp

--- a/src/main/com/yetanalytics/datasim/xapi/profile/pattern.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/pattern.clj
@@ -279,9 +279,4 @@
         (t/local-date-time the-instant "UTC")
         {:alternates [:pattern-A #_:pattern-B]})
        (take 8))
-  
-  (temporal/next-bounded-time
-   (temporal/convert-bounds [{:years [2023 2024]
-                              :minutes [0]}])
-   (t/local-date-time the-instant "UTC"))
   )

--- a/src/main/com/yetanalytics/datasim/xapi/profile/pattern.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/pattern.clj
@@ -1,5 +1,6 @@
 (ns com.yetanalytics.datasim.xapi.profile.pattern
-  "Creation of `pattern-walk-fn` for Profile compilation."
+  "Pattern map compilation and walking. This is where the magic of
+   profile simulation happens."
   (:require [clojure.spec.alpha :as s]
             [java-time.api      :as t]
             [com.yetanalytics.pan.objects.template   :as template]

--- a/src/test/com/yetanalytics/datasim/input/models_test.clj
+++ b/src/test/com/yetanalytics/datasim/input/models_test.clj
@@ -25,9 +25,9 @@
               :weight 0.1}
              {:id     "http://www.whatever.com/pattern1/child"
               :weight 0.9}]
-   :period  {:min  2.1
-             :mean 3
-             :unit "weeks"}})
+   :periods [{:min  2.1
+              :mean 3
+              :unit "weeks"}]})
 
 (def pat-alignment-2
   {:id         "http://www.whatever.com/pattern2"
@@ -42,9 +42,9 @@
                  :daysOfMonth [[1 10] [21 30]]
                  :months      [1 ["April" "May"]]
                  :years       [2023]}]
-   :period     {:min  2
-                :mean 3.2
-                :unit "millis"}
+   :periods    [{:min  2
+                 :mean 3.2
+                 :unit "millis"}]
    :retry      "template"
    :repeat-max 10})
 
@@ -110,17 +110,17 @@
     (is (not (s/valid? ::model/patterns
                        [(assoc-in pat-alignment-1 [:bounds 0 :minutes] [60])])))
     (is (not (s/valid? ::model/patterns
-                       [(assoc-in pat-alignment-1 [:period :mean] 0)])))
+                       [(assoc-in pat-alignment-1 [:periods 0 :mean] 0)])))
     (is (not (s/valid? ::model/patterns
-                       [(assoc-in pat-alignment-1 [:period :mean] -3)])))
+                       [(assoc-in pat-alignment-1 [:periods 0 :mean] -3)])))
     (is (not (s/valid? ::model/patterns
-                       [(assoc-in pat-alignment-1 [:period :mean] "4")])))
+                       [(assoc-in pat-alignment-1 [:periods 0 :mean] "4")])))
     (is (not (s/valid? ::model/patterns
-                       [(assoc-in pat-alignment-1 [:period :min] -1.2)])))
+                       [(assoc-in pat-alignment-1 [:periods 0 :min] -1.2)])))
     (is (not (s/valid? ::model/patterns
-                       [(assoc-in pat-alignment-1 [:period :min] "3")])))
+                       [(assoc-in pat-alignment-1 [:periods 0 :min] "3")])))
     (is (not (s/valid? ::model/patterns
-                       [(assoc-in pat-alignment-1 [:period :unit] "months")]))))
+                       [(assoc-in pat-alignment-1 [:periods 0 :unit] "months")]))))
   (testing "object overrides"
     (is (s/valid? ::model/objectOverrides
                   [object-override-example]))

--- a/src/test/com/yetanalytics/datasim/input/models_test.clj
+++ b/src/test/com/yetanalytics/datasim/input/models_test.clj
@@ -52,8 +52,7 @@
                  :bounds [{:years [2024]}]}
                 {:fixed  2
                  :mean   3.1 ; would be ignored
-                 :unit   "millis"
-                 :bounds [{:years [2024]}]}]
+                 :unit   "millis"}]
    :retry      "template"
    :repeat-max 10})
 
@@ -129,7 +128,9 @@
     (is (not (s/valid? ::model/patterns
                        [(assoc-in pat-alignment-1 [:periods 0 :min] "3")])))
     (is (not (s/valid? ::model/patterns
-                       [(assoc-in pat-alignment-1 [:periods 0 :unit] "months")]))))
+                       [(assoc-in pat-alignment-1 [:periods 0 :unit] "months")])))
+    (is (not (s/valid? ::model/patterns
+                       [(assoc-in pat-alignment-2 [:periods 2 :bounds] [{:years [2024]}])]))))
   (testing "object overrides"
     (is (s/valid? ::model/objectOverrides
                   [object-override-example]))

--- a/src/test/com/yetanalytics/datasim/input/models_test.clj
+++ b/src/test/com/yetanalytics/datasim/input/models_test.clj
@@ -41,10 +41,15 @@
                  :daysOfWeek  ["Sunday" "Tuesday" "Thursday"]
                  :daysOfMonth [[1 10] [21 30]]
                  :months      [1 ["April" "May"]]
-                 :years       [2023]}]
-   :periods    [{:min  2
-                 :mean 3.2
-                 :unit "millis"}]
+                 :years       [2023 2024]}]
+   :periods    [{:min    2
+                 :mean   3.2
+                 :unit   "millis"
+                 :bounds [{:years [2023]}]}
+                {:min    8
+                 :mean   1.1
+                 :unit   "millis"
+                 :bounds [{:years [2024]}]}]
    :retry      "template"
    :repeat-max 10})
 

--- a/src/test/com/yetanalytics/datasim/input/models_test.clj
+++ b/src/test/com/yetanalytics/datasim/input/models_test.clj
@@ -49,6 +49,10 @@
                 {:min    8
                  :mean   1.1
                  :unit   "millis"
+                 :bounds [{:years [2024]}]}
+                {:fixed  2
+                 :mean   3.1 ; would be ignored
+                 :unit   "millis"
                  :bounds [{:years [2024]}]}]
    :retry      "template"
    :repeat-max 10})

--- a/src/test/com/yetanalytics/datasim/model/temporal_test.clj
+++ b/src/test/com/yetanalytics/datasim/model/temporal_test.clj
@@ -1,0 +1,422 @@
+(ns com.yetanalytics.datasim.model.temporal-test
+  (:require [clojure.test :refer [deftest testing is are]]
+            [java-time.api :as t]
+            [com.yetanalytics.datasim.math.random :as random]
+            [com.yetanalytics.datasim.model.temporal :as temporal]))
+
+(deftest time-helpers-test
+  (testing "time-map"
+    (is (= {:year         2023
+            :month        9
+            :day-of-month 19
+            :day-of-week  2
+            :hour         11
+            :minute       12
+            :second       13}
+           (temporal/time-map
+            (t/local-date-time 2023 9 19 11 12 13)))))
+  (testing "`leap-year?` function"
+    (is (true? (temporal/leap-year? 2024)))
+    (is (true? (temporal/leap-year? 2000)))
+    (is (false? (temporal/leap-year? 2023)))
+    (is (false? (temporal/leap-year? 1900))))
+  (testing "`day-of-month?` function"
+    (testing "(non-leap year)"
+      (are [month days]
+           (->> days
+                (map (fn [d] (temporal/day-of-month? 2023 month d)))
+                (every? true?))
+        1 (range 32)
+        2 (range 29)
+        3 (range 32)
+        4 (range 31)
+        5 (range 32)
+        6 (range 31)
+        7 (range 32)
+        8 (range 32)
+        9 (range 31)
+        10 (range 32)
+        11 (range 31)
+        12 (range 32))
+      (are [month day]
+           (false? (temporal/day-of-month? 2023 month day))
+        1 32
+        2 29
+        3 32
+        4 31
+        5 32
+        6 32
+        6 31
+        7 32
+        8 32
+        9 31
+        10 32
+        11 31
+        12 32))
+    (testing "(leap year)"
+      (are [month days]
+           (->> days
+                (map (fn [d] (temporal/day-of-month? 2024 month d)))
+                (every? true?))
+        1 (range 32)
+        2 (range 30) ; different from non-leap year
+        3 (range 32)
+        4 (range 31)
+        5 (range 32)
+        6 (range 31)
+        7 (range 32)
+        8 (range 32)
+        9 (range 31)
+        10 (range 32)
+        11 (range 31)
+        12 (range 32))))
+  (testing "`day-of-week` function"
+    (is (= 2 ; Tuesday
+           (temporal/day-of-week 2023 9 19)))
+    (is (= 0 ; Sunday
+           (temporal/day-of-week 2023 1 1)))
+    (is (= 1 ; Monday
+           (temporal/day-of-week 2024 9 9)))))
+
+(def new-years-date-time
+  "The first moment of 2023, 2023-01-01T00:00:00, as a LocalDateTime"
+  (t/local-date-time 2023 1 1 0 0 0))
+
+(def year-midpoint-date-time
+  "The middle of 2023, 2023-06-15T12:30:30, as a LocalDateTime"
+  (t/local-date-time 2023 6 15 12 30 30))
+
+(deftest bounds-test
+  (testing "`convert-bounds` function"
+    (is (= [{:ranges {:seconds       '(1 2 3)
+                      :minutes       '(1)
+                      :hours         '(8 9 10 11 12)
+                      :days-of-week  '(0 2 4)
+                      :days-of-month '(1 2 3 4 5 6 7 8 9 10 21 22 23 24 25 26 27 28 29 30)
+                      :months        '(1 4 5)
+                      :years         '(2023 2024)}
+             :sets   {:seconds       #{1 2 3}
+                      :minutes       #{1}
+                      :hours         #{8 9 10 11 12}
+                      :days-of-week  #{0 2 4}
+                      :days-of-month #{1 2 3 4 5 6 7 8 9 10 21 22 23 24 25 26 27 28 29 30}
+                      :months        #{1 4 5}
+                      :years         #{2023 2024}}}]
+           (temporal/convert-bounds
+            [{:seconds     [1 2 3]
+              :minutes     [1]
+              :hours       [[8 12]]
+              :daysOfWeek  ["Sunday" "Tuesday" "Thursday"]
+              :daysOfMonth [[1 10] [21 30]]
+              :months      [1 ["April" "May"]]
+              :years       [2023 2024]}])))
+    (is (= [{:ranges {:years '(2021 2022 2023 2024)}
+             :sets   {:years #{2021 2022 2023 2024}}}
+            {:ranges {:years '(1971 1972 1973 1974)}
+             :sets   {:years #{1971 1972 1973 1974}}}]
+           (temporal/convert-bounds
+            [{:years [2024 2023 2022 2021]}
+             {:years [1974 1973 1972 1971]}]))))
+  (testing "`bounded-time?` function"
+    (testing "(always true if bounds are empty)"
+      (is (true? (temporal/bounded-time?
+                  nil
+                  (t/local-date-time (t/instant) "UTC"))))
+      (is (true? (temporal/bounded-time?
+                  []
+                  (t/local-date-time (t/instant) "UTC")))))
+    (testing "(non-empty bounds)"
+      (are [res bounds]
+           (= res (temporal/bounded-time?
+                   (temporal/convert-bounds bounds)
+                   new-years-date-time))
+        ;; year bounds
+        true  [{:years [2023 2024]}]
+        true  [{:years [[2023 2024]]}]
+        true  [{:years [2023]} {:years [2024]}]
+        false [{:years [2024]}]
+        ;; month bounds
+        true  [{:years  [2023]
+                :months [1 2 3]}]
+        true  [{:months [1 2 3]}]
+        true  [{:years  [2023]
+                :months [1]}
+               {:years  [2024]
+                :months [2]}]
+        false [{:years  [2023]
+                :months [2 3 4]}]
+        false [{:months [2 3 4]}]
+        ;; day of month bounds
+        true  [{:years       [2023]
+                :months      [1]
+                :daysOfMonth [1 2 3]}]
+        true  [{:years       [2023]
+                :months      [1]
+                :daysOfMonth [[1 3]]}]
+        true  [{:years       [2023]
+                :daysOfMonth [[1 3]]}
+               {:years       [2024]
+                :daysOfMonth [[4 6]]}]
+        true  [{:daysOfMonth [[1 12]]}]
+        false [{:years       [2023]
+                :months      [1]
+                :daysOfMonth [4 5 6]}]
+        ;; day of week bounds
+        true  [{:years       [2023]
+                :months      [1]
+                :daysOfWeek  [0]}]
+        true  [{:years      [2023]
+                :months     [1]
+                :daysOfWeek [[0 6]]}]
+        false [{:years      [2023]
+                :months     [1]
+                :daysOfWeek [[1 6]]}]
+        true  [{:years       [2023]
+                :months      [1]
+                :daysOfWeek  [0]
+                :daysOfMonth [1]}]
+        false [{:years       [2023]
+                :months      [1]
+                :daysOfWeek  [0]
+                :daysOfMonth [2]}]
+        ;; hour bounds
+        true  [{:years       [2023]
+                :months      [1]
+                :daysOfMonth [1]
+                :hours       [0]}]
+        false [{:years       [2023]
+                :months      [1]
+                :daysOfMonth [1]
+                :hours       [1]}]
+        true  [{:hours [0]}]
+        true  [{:hours [[0 14]]}]
+        true  [{:daysOfWeek [1]
+                :hours      [[12 23]]}
+               {:daysOfWeek [0]
+                :hours      [[0 11]]}]
+        false [{:daysOfWeek [0]
+                :hours      [[12 23]]}
+               {:daysOfWeek [1]
+                :hours      [[0 11]]}]
+        ;; minute bounds
+        true  [{:years       [2023]
+                :months      [1]
+                :daysOfMonth [1]
+                :hour        [0]
+                :minutes     [0]}]
+        false [{:years       [2023]
+                :months      [1]
+                :daysOfMonth [1]
+                :hour        [0]
+                :minutes     [1]}]
+        true  [{:minutes [[0 29]]}]
+        true  [{:minutes [[30 59]]}
+               {:minutes [[0 29]]}]
+        false [{:minutes [[30 59]]}]
+        ;; second bounds
+        true  [{:years       [2023]
+                :months      [1]
+                :daysOfMonth [1]
+                :hour        [0]
+                :minutes     [0]
+                :seconds     [0]}]
+        false [{:years       [2023]
+                :months      [1]
+                :daysOfMonth [1]
+                :hour        [0]
+                :minutes     [0]
+                :seconds     [1]}]
+        true  [{:seconds [[0 29]]}]
+        true  [{:seconds [[30 59]]}
+               {:seconds [[0 29]]}]
+        false [{:seconds [[30 59]]}])))
+  (testing "`next-bounded-time` function"
+    (are [expected bounds]
+         (= (t/local-date-time expected)
+            (temporal/next-bounded-time
+             (temporal/convert-bounds bounds)
+             new-years-date-time))
+      "2023-01-01T00:00:00" [{:years [2023 2024]}] ; no change
+      "2024-01-01T00:00:00" [{:years [2024]}]
+      "2023-02-01T00:00:00" [{:months [2]}]
+      "2023-01-02T00:00:00" [{:daysOfMonth [2]}]
+      "2023-01-02T00:00:00" [{:daysOfWeek [1]}]
+      "2023-01-01T01:00:00" [{:hours [1]}]
+      "2023-01-01T00:01:00" [{:minutes [1]}]
+      "2023-01-01T00:00:01" [{:seconds [1]}]
+      "2024-02-02T01:01:01" [{:years       [2024]
+                              :months      [2]
+                              :daysOfMonth [2]
+                              :daysOfWeek  ["Friday"]
+                              :hours       [1]
+                              :minutes     [1]
+                              :seconds     [1]}]
+      "2025-01-01T00:00:00" [{:years [2025]}
+                             {:years [2024]}]
+      "2023-01-01T00:00:00" [{:years       [2023] ; no change
+                              :months      [1]
+                              :daysOfMonth [1]
+                              :daysOfWeek  [0]
+                              :hours       [0]
+                              :minutes     [0]
+                              :seconds     [0]}])
+    (are [expected bounds]
+         (= (t/local-date-time expected)
+            (temporal/next-bounded-time
+             (temporal/convert-bounds bounds)
+             year-midpoint-date-time))
+      "2023-06-15T12:30:30" [{:years       [2023] ; no change
+                              :months      [6]
+                              :daysOfMonth [15]
+                              :daysOfWeek  ["Thursday"]
+                              :hours       [12]
+                              :minutes     [30]
+                              :seconds     [30]}]
+      "2023-07-01T00:00:00" [{:months [7]}]
+      "2024-05-01T00:00:00" [{:months [5]}]
+      "2023-06-16T00:00:00" [{:daysOfMonth [16]}]
+      "2023-07-14T00:00:00" [{:daysOfMonth [14]}]
+      "2023-06-16T00:00:00" [{:daysOfWeek ["Friday"]}]
+      "2023-06-21T00:00:00" [{:daysOfWeek ["Wednesday"]}]
+      "2023-06-15T13:00:00" [{:hours [13]}]
+      "2023-06-16T11:00:00" [{:hours [11]}]
+      "2023-06-15T12:31:00" [{:minutes [31]}]
+      "2023-06-15T13:29:00" [{:minutes [29]}]
+      "2023-06-15T12:30:31" [{:seconds [31]}]
+      "2023-06-15T12:31:29" [{:seconds [29]}])
+    (testing "(time bound exceeded)"
+      (is (nil? (temporal/next-bounded-time
+                 (temporal/convert-bounds [{:years [2022]}])
+                 new-years-date-time)))
+      (is (nil? (temporal/next-bounded-time
+                 (temporal/convert-bounds [{:years  [2023]
+                                            :months [5]}])
+                 year-midpoint-date-time)))
+      (is (nil? (temporal/next-bounded-time
+                 (temporal/convert-bounds [{:years       [2023]
+                                            :months      [6]
+                                            :daysOfMonth [15]
+                                            :hours       [12]
+                                            :minutes     [30]
+                                            :seconds     [29]}])
+                 year-midpoint-date-time))))
+    (testing "(daysOfWeek filters out otherwise valid dates)"
+      (is (nil? (temporal/next-bounded-time
+                 (temporal/convert-bounds [{:years       [2024]
+                                            :months      [2]
+                                            :daysOfMonth [2]
+                                            :daysOfWeek  ["Thursday"]}])
+                 new-years-date-time))))))
+
+(deftest time-period-test
+  (testing "`convert-periods?` function"
+    (is (= [{:min  2
+             :mean 2}
+            {:min  2000
+             :mean 2000}
+            {:min  120000
+             :mean 120000}
+            {:min  7200000
+             :mean 7200000}
+            {:min  172800000
+             :mean 172800000}
+            {:min  1209600000
+             :mean 1209600000}]
+           (temporal/convert-periods
+            [{:min   2
+              :mean  2
+              :unit  "millis"}
+             {:min   2
+              :mean  2
+              :unit  "seconds"}
+             {:min   2
+              :mean  2
+              :unit  "minutes"}
+             {:min   2
+              :mean  2
+              :unit  "hours"}
+             {:min   2
+              :mean  2
+              :unit  "days"}
+             {:min   2
+              :mean  2
+              :unit  "weeks"}])))
+    (is (= [{:fixed 2}
+            {:fixed 2000}
+            {:fixed 120000}
+            {:fixed 7200000}
+            {:fixed 172800000}
+            {:fixed 1209600000}]
+           (temporal/convert-periods
+            [{:fixed 2
+              :unit "millis"}
+             {:fixed 2
+              :unit "seconds"}
+             {:fixed 2
+              :unit "minutes"}
+             {:fixed 2
+              :unit "hours"}
+             {:fixed 2
+              :unit "days"}
+             {:fixed 2
+              :unit "weeks"}])))
+    (is (= [{:min  60000 ; minute default
+             :mean 60000}
+            {:fixed 60000}]
+           (temporal/convert-periods
+            [{:min  1
+              :mean 1}
+             {:min   1
+              :mean  1
+              :fixed 1}]))))
+  (testing "`add-periods` function"
+    (testing "(fixed times)"
+      (are [expected periods]
+           (= (t/local-date-time expected)
+              (temporal/add-periods
+               new-years-date-time
+               (random/seed-rng 100) ; rng doesn't matter here
+               (temporal/convert-periods periods)))
+        "2023-01-01T00:01:00" [{:fixed 1}]
+        "2023-01-01T00:30:00" [{:fixed 1
+                                :bounds [{:years [2024]}]}
+                               {:fixed 30
+                                :bounds [{:years [2023]}]}]))
+    (testing "(minimum times)"
+      (are [expected-min periods]
+           (t/before?
+            (t/local-date-time expected-min)
+            (temporal/add-periods
+             new-years-date-time
+             (random/rng)
+             (temporal/convert-periods periods)))
+        "2023-01-01T00:00:30" [{:min  30
+                                :unit "seconds"}]
+        "2023-01-01T00:30:00" [{:min  30
+                                :unit "minutes"}]
+        "2023-01-01T12:00:00" [{:min  12
+                                :unit "hours"}]
+        "2023-01-10T00:00:00" [{:min 10
+                                :unit "days"}]
+        "2023-01-14T00:00:00" [{:min 2
+                                :unit "weeks"}]))
+    (testing "(mean times)"
+      ;; We use 6 * sd = 6 * mean (b/c exponential distribution)
+      (are [expected-max periods]
+           (t/before?
+            new-years-date-time
+            (temporal/add-periods
+             new-years-date-time
+             (random/rng)
+             (temporal/convert-periods periods))
+            (t/local-date-time expected-max))
+        "2023-01-01T00:03:00" [{:mean 30
+                                :unit "seconds"}]
+        "2023-01-01T00:30:00" [{:mean 5
+                                :unit "minutes"}]
+        "2023-01-01T12:00:00" [{:mean 2
+                                :unit "hours"}]
+        "2023-01-06T00:00:00" [{:mean 1
+                                :unit "days"}]
+        "2023-01-21T00:00:00" [{:mean 0.5
+                                :unit "weeks"}]))))


### PR DESCRIPTION
Apply the following changes to temporal periods:
- Change `period` to `periods`, an _array_ of period maps, where the first period that satisfies the current timestamp is used
- Add the `bounds` property to dictate the temporal bounds a timestamp is valid in, similar to the top-level `bounds` property
- Add a `fixed` property, to specify a fixed instead of randomized amount of time between statements (this will be helpful during debugging)

TODOs:
- [x] Add tests to the temporal namespaces
- [ ] Add tests for `fixed` and different period `bounds` (will be done in a test suite-specific PR)