### PR TITLE
GQL-friendly bound inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,12 @@ and `weight` values (as described under `verbs`).
 - `patterns`: An array of objects with Pattern `id` and the following additional optional values:
   - `weights`: An array of child Pattern/Template `id` and `weight` values. Each weight affects how likely each of the Pattern's child patterns are chosen (for `alternates`) or how likely the child Pattern will be selected at all (for `optional`, for these `null` is also a valid option). This has no effect on `sequence`, `zeroOrMore`, or `oneOrMore` Patterns.
   - `repeat-max`: A positive integer representing the maximum number of times (exclusive) the child pattern can be generated. Only affects `zeroOrMore` and `oneOrMore` patterns.
-  - `bounds`: An array of objects containing key-value pairs where each value is an array of singular values (e.g. `"January"`) or arrays of start, end, and optional step values (e.g. `["January", "October"]`). For example `{"years": [2023], "months": [[1, 5]]}` describes an inclusive bound from January to May 2023; making the `months` bound `[[1, 5, 2]]` would have restricted it to only January, March, and May 2023. If not present, `bounds` indicates an infinite bound, such that any timestamp is valid. The following are valid bound values:
+  - `bounds`: An array of objects containing key-value pairs where each value is an array, whose entries are one of the following:
+    - A singular value, day of week name, or month name (e.g. `"January"`)
+    - An array with start, end, and optional step values (e.g. `["January", "October"]`)
+    - An object with `start`, `end`, and an optional `step` value (e.g. `{"start": "January", "end": "October}`)
+
+    For example `{"years": [2023], "months": [[1, 5]]}` describes an inclusive bound from January to May 2023; making the `months` bound `[[1, 5, 2]]` would have restricted it to only January, March, and May 2023. If not present, `bounds` indicates an infinite bound, such that any timestamp is valid. The following are valid bound values:
     - `years`: Any positive integer
     - `months`: `1` to `12`, or their name equivalents, i.e. `"January"` to `"December"`
     - `daysOfMonth:` `1` to `31` (though `29` or `30` are skipped at runtime for months that do not include these days)

--- a/src/main/com/yetanalytics/datasim/input/model/alignments.clj
+++ b/src/main/com/yetanalytics/datasim/input/model/alignments.clj
@@ -44,7 +44,7 @@
   [start end])
 
 (defn- interval? [[start end]]
-  (< start end))
+  (<= start end))
 
 (defmacro bound-spec [scalar-spec]
   `(s/every (s/or :scalar

--- a/src/main/com/yetanalytics/datasim/input/model/alignments.clj
+++ b/src/main/com/yetanalytics/datasim/input/model/alignments.clj
@@ -36,6 +36,13 @@
 ;; Time Bounds
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(s/def ::bounds/start nat-int?)
+(s/def ::bounds/end nat-int?)
+(s/def ::bounds/step pos-int?)
+
+(defn- interval-map->tuple [{:keys [start end]}]
+  [start end])
+
 (defn- interval? [[start end]]
   (< start end))
 
@@ -47,6 +54,12 @@
                          interval?)
                   :step-interval
                   (s/and (s/tuple ~scalar-spec ~scalar-spec pos-int?)
+                         interval?)
+                  :map
+                  (s/and (s/keys :req-un [::bounds/start ::bounds/end]
+                                 :opt-un [::bounds/step])
+                         (s/conformer interval-map->tuple)
+                         (s/tuple ~scalar-spec ~scalar-spec)
                          interval?))
             :kind vector?
             :min-count 1

--- a/src/main/com/yetanalytics/datasim/model/bounds.clj
+++ b/src/main/com/yetanalytics/datasim/model/bounds.clj
@@ -201,16 +201,26 @@
     :daysOfMonth :days-of-month
     unit))
 
+(defn- values->range
+  [start end ?step]
+  (let [start* (string->int start)
+        end*   (inc (string->int end))]
+    (if ?step
+      (range start* end* ?step)
+      (range start* end*))))
+
 (defn- reduce-values
   [vs* v]
-  (if (coll? v)
-    (let [[start end ?step] v
-          start* (string->int start)
-          end*   (inc (string->int end))
-          vrange (if ?step
-                   (range start* end* ?step)
-                   (range start* end*))]
+  (cond
+    (map? v)
+    (let [{:keys [start end step]} v
+          vrange (values->range start end step)]
       (into vs* vrange))
+    (coll? v)
+    (let [[start end step] v
+          vrange (values->range start end step)]
+      (into vs* vrange))
+    :else
     (let [v* (string->int v)]
       (conj vs* v*))))
 

--- a/src/test/com/yetanalytics/datasim/input/models_test.clj
+++ b/src/test/com/yetanalytics/datasim/input/models_test.clj
@@ -39,7 +39,7 @@
                     :minutes     [[0 59 2]]
                     :hours       [[8 12]]
                     :daysOfWeek  ["Sunday" "Tuesday" "Thursday"]
-                    :daysOfMonth [[1 10] [21 30]]
+                    :daysOfMonth [{:start 1 :end 10} {:start 21 :end 30 :step 2}]
                     :months      [1 ["April" "May"]]
                     :years       [2023 2024]}]
    :boundRestarts ["http://www.whatever.com/pattern1"]

--- a/src/test/com/yetanalytics/datasim/model/bounds_test.clj
+++ b/src/test/com/yetanalytics/datasim/model/bounds_test.clj
@@ -91,14 +91,14 @@
                       :minutes       '(1)
                       :hours         '(8 9 10 11 12)
                       :days-of-week  '(0 2 4)
-                      :days-of-month '(1 2 3 4 5 6 7 8 9 10 21 22 23 24 25 26 27 28 29 30)
+                      :days-of-month '(1 2 3 4 5 6 7 8 9 10 21 23 25 27 29)
                       :months        '(1 4 5)
                       :years         '(2023 2024)}
              :sets   {:seconds       #{1 2 3}
                       :minutes       #{1}
                       :hours         #{8 9 10 11 12}
                       :days-of-week  #{0 2 4}
-                      :days-of-month #{1 2 3 4 5 6 7 8 9 10 21 22 23 24 25 26 27 28 29 30}
+                      :days-of-month #{1 2 3 4 5 6 7 8 9 10 21 23 25 27 29}
                       :months        #{1 4 5}
                       :years         #{2023 2024}}}]
            (bounds/convert-bounds
@@ -106,9 +106,19 @@
               :minutes     [1]
               :hours       [[8 12]]
               :daysOfWeek  ["Sunday" "Tuesday" "Thursday"]
-              :daysOfMonth [[1 10] [21 30]]
+              :daysOfMonth [{:start 1 :end 10} {:start 21 :end 30 :step 2}]
               :months      [1 ["April" "May"]]
               :years       [2023 2024]}])))
+    (is (= [{:ranges {:seconds '(0)
+                      :minutes '(0)
+                      :hours   '(0)}
+             :sets   {:seconds #{0}
+                      :minutes #{0}
+                      :hours   #{0}}}]
+           (bounds/convert-bounds
+            [{:seconds [0]
+              :minutes [[0 0]]
+              :hours   [{:start 0 :end 0}]}])))
     (is (= [{:ranges {:seconds       '(0 2 4 6 8 10 12 14 16 18 20 22 24 26 28 30)
                       :minutes       '(0 2 4 6 8 10 12 14 16 18 20 22 24 26 28 30)
                       :hours         '(0 6 12 18)


### PR DESCRIPTION
Add a new syntax for bound inputs: a map with `start`, `end`, and optional `step` properties. For example:
```json
{
  "start": "January",
  "end": "November",
  "step": 2
}
```
This new input is for ease of use with applications with GraphQL APIs (e.g. Centriph), as this is the natural form of a GraphQL input type.