### PR TITLE
Change typo in periodic NVD scan workflow

### DIFF
--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -13,4 +13,4 @@ jobs:
       nvd-config-filename: '.nvd/config.json'
       notify-slack: true
     secrets:
-      SLACK_WORKFLOW_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
For months, a typo in the periodic NVD scan workflow has caused the scan to fail silently _for the past 8 months!_ Hopefully this will fix it.