### PR TITLE
Fix activity generation bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.4.1] - 2024-01-25
+- Fix a number of bugs associated with Statement generation:
+  - Fix places where `:definition` was used when `:activityDefinition` was supposed to be used in the code, causing Activities not to be associated with their respective Activity Types.
+  - Stringify keys for map values of `any`, `all`, and `none` in Statement Template rules.
+
 ## [0.4.0] - 2024-01-03
 - Change `alignments` inputs to `models` inputs that incorporate additional temporal properties.
 - Make `models` an array in which the user can apply different `personae` to.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 GROUP_ID ?= com.yetanalytics
 ARTIFACT_ID ?= datasim
-VERSION ?= 0.4.0
+VERSION ?= 0.4.1
 
 clean:
 	rm -rf target

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ DATASIM is funded by the Advanced Distributed Learning Initiative at US DoD.
 To use the core DATASIM library in your project, use the following dependency in your `deps.edn` file:
 
 ```clojure
-com.yetanalytics/datasim {:mvn/version "0.4.0"}
+com.yetanalytics/datasim {:mvn/version "0.4.1"}
 ```
 
 If you wish to install DATASIM as an application with features such as CLI or the webserver, perform the following steps:

--- a/dev-resources/profiles/activity.jsonld
+++ b/dev-resources/profiles/activity.jsonld
@@ -1,0 +1,153 @@
+{
+    "id": "https://xapinet.org/xapi/yet/activity-profile",
+    "type": "Profile",
+    "@context": "https://w3id.org/xapi/profiles/context",
+    "conformsTo": "https://w3id.org/xapi/profiles#1.0",
+    "prefLabel": {
+        "en": "Activity Test Profile"
+    },
+    "definition": {
+        "en": "This Profile is intended to test Activity and Activity Types"
+    },
+    "versions": [
+        {
+            "id": "https://xapinet.org/xapi/yet/activity-profile/v1",
+            "generatedAtTime": "2024-01-25T10:10:10Z"
+        }
+    ],
+    "author": {
+        "url": "https://www.yetanalytics.com/",
+        "name": "Yet Analytics",
+        "type": "Organization"
+    },
+    "concepts": [
+        {
+            "id": "https://xapinet.org/xapi/yet/activity/nontyped",
+            "type": "Activity",
+            "inScheme": "https://xapinet.org/xapi/yet/activity-profile/v1",
+            "activityDefinition": {
+                "@context": "https://w3id.org/xapi/profiles/activity-context",
+                "name": {
+                    "en": "Activity without Activity Type"
+                },
+                "description": {
+                    "en": "Activity without Activity Type"
+                }
+            }
+        },
+        {
+            "id": "https://xapinet.org/xapi/yet/activity/typed",
+            "type": "Activity",
+            "inScheme": "https://xapinet.org/xapi/yet/activity-profile/v1",
+            "activityDefinition": {
+                "@context": "https://w3id.org/xapi/profiles/activity-context",
+                "name": {
+                    "en": "Activity with Activity Type"
+                },
+                "description": {
+                    "en": "Activity with Activity Type"
+                },
+                "type": "https://xapinet.org/xapi/yet/activity-type"
+            }
+        },
+        {
+            "id": "https://xapinet.org/xapi/yet/activity-type",
+            "type": "ActivityType",
+            "inScheme": "https://xapinet.org/xapi/yet/activity-profile/v1",
+            "prefLabel": {
+                "en": "Activity Type Label"
+            },
+            "definition": {
+                "en": "Activity Type Definition"
+            }
+        }
+    ],
+    "templates": [
+        {
+            "id": "https://xapinet.org/xapi/yet/template/1",
+            "type": "StatementTemplate",
+            "inScheme": "https://xapinet.org/xapi/yet/activity-profile/v1",
+            "prefLabel": {
+                "en": "Template 1"
+            },
+            "definition": {
+                "en": "Template to test objectActivityType"
+            },
+            "objectActivityType": "https://xapinet.org/xapi/yet/activity-type"
+        },
+        {
+            "id": "https://xapinet.org/xapi/yet/template/2",
+            "type": "StatementTemplate",
+            "inScheme": "https://xapinet.org/xapi/yet/activity-profile/v1",
+            "prefLabel": {
+                "en": "Template 2"
+            },
+            "definition": {
+                "en": "Template to test activity type referenced in activity definition"
+            },
+            "rules": [
+                {
+                    "location": "$.object.definition",
+                    "presence": "included",
+                    "all": [{"type": "https://xapinet.org/xapi/yet/activity-type"}]
+                }
+            ]
+        },
+        {
+            "id": "https://xapinet.org/xapi/yet/template/3",
+            "type": "StatementTemplate",
+            "inScheme": "https://xapinet.org/xapi/yet/activity-profile/v1",
+            "prefLabel": {
+                "en": "Template 3"
+            },
+            "definition": {
+                "en": "Template to test activity type referenced by ID"
+            },
+            "rules": [
+                {
+                    "location": "$.object.definition.type",
+                    "presence": "included",
+                    "all": ["https://xapinet.org/xapi/yet/activity-type"]
+                }
+            ]
+        },
+        {
+            "id": "https://xapinet.org/xapi/yet/template/4",
+            "type": "StatementTemplate",
+            "inScheme": "https://xapinet.org/xapi/yet/activity-profile/v1",
+            "prefLabel": {
+                "en": "Template 4"
+            },
+            "definition": {
+                "en": "Template to test activity referenced by ID"
+            },
+            "rules": [
+                {
+                    "location": "$.object.id",
+                    "presence": "included",
+                    "all": ["https://xapinet.org/xapi/yet/activity/nontyped"]
+                }
+            ]
+        }
+    ],
+    "patterns": [
+        {
+            "id": "https://xapi.org/xapi/yet/pattern",
+            "type": "Pattern",
+            "inScheme": "https://xapinet.org/xapi/yet/activity-profile/v1",
+            "primary": true,
+            "prefLabel": {
+                "en": "Primary Pattern"
+            },
+            "definition": {
+                "en": "Sequence pattern for templates 1 to 4"
+            },
+            "sequence": [
+                "https://xapinet.org/xapi/yet/template/1",
+                "https://xapinet.org/xapi/yet/template/2",
+                "https://xapinet.org/xapi/yet/template/3",
+                "https://xapinet.org/xapi/yet/template/4"
+            ]
+        }
+    ]
+}

--- a/dev-resources/profiles/activity.jsonld
+++ b/dev-resources/profiles/activity.jsonld
@@ -71,9 +71,13 @@
                 "en": "Template 1"
             },
             "definition": {
-                "en": "Template to test objectActivityType"
+                "en": "Template to test Activity Type determining properties"
             },
-            "objectActivityType": "https://xapinet.org/xapi/yet/activity-type"
+            "objectActivityType": "https://xapinet.org/xapi/yet/activity-type",
+            "contextGroupingActivityType": ["https://xapinet.org/xapi/yet/activity-type"],
+            "contextParentActivityType": ["https://xapinet.org/xapi/yet/activity-type"],
+            "contextOtherActivityType": ["https://xapinet.org/xapi/yet/activity-type"],
+            "contextCategoryActivityType": ["https://xapinet.org/xapi/yet/activity-type"]
         },
         {
             "id": "https://xapinet.org/xapi/yet/template/2",
@@ -88,6 +92,21 @@
             "rules": [
                 {
                     "location": "$.object.definition",
+                    "presence": "included",
+                    "all": [{"type": "https://xapinet.org/xapi/yet/activity-type"}]
+                },
+                {
+                    "location": "$.context.contextActivities.grouping[0].definition",
+                    "presence": "included",
+                    "all": [{"type": "https://xapinet.org/xapi/yet/activity-type"}]
+                },
+                {
+                    "location": "$.context.contextActivities.parent[0].definition",
+                    "presence": "included",
+                    "all": [{"type": "https://xapinet.org/xapi/yet/activity-type"}]
+                },
+                {
+                    "location": "$.context.contextActivities.other[0].definition",
                     "presence": "included",
                     "all": [{"type": "https://xapinet.org/xapi/yet/activity-type"}]
                 }
@@ -108,6 +127,21 @@
                     "location": "$.object.definition.type",
                     "presence": "included",
                     "all": ["https://xapinet.org/xapi/yet/activity-type"]
+                },
+                {
+                    "location": "$.context.contextActivities.grouping[0].definition.type",
+                    "presence": "included",
+                    "all": ["https://xapinet.org/xapi/yet/activity-type"]
+                },
+                {
+                    "location": "$.context.contextActivities.parent[0].definition.type",
+                    "presence": "included",
+                    "all": ["https://xapinet.org/xapi/yet/activity-type"]
+                },
+                {
+                    "location": "$.context.contextActivities.other[0].definition.type",
+                    "presence": "included",
+                    "all": ["https://xapinet.org/xapi/yet/activity-type"]
                 }
             ]
         },
@@ -124,6 +158,21 @@
             "rules": [
                 {
                     "location": "$.object.id",
+                    "presence": "included",
+                    "all": ["https://xapinet.org/xapi/yet/activity/nontyped"]
+                },
+                {
+                    "location": "$.context.contextActivities.grouping[0].id",
+                    "presence": "included",
+                    "all": ["https://xapinet.org/xapi/yet/activity/nontyped"]
+                },
+                {
+                    "location": "$.context.contextActivities.parent[0].id",
+                    "presence": "included",
+                    "all": ["https://xapinet.org/xapi/yet/activity/nontyped"]
+                },
+                {
+                    "location": "$.context.contextActivities.other[0].id",
                     "presence": "included",
                     "all": ["https://xapinet.org/xapi/yet/activity/nontyped"]
                 }

--- a/src/main/com/yetanalytics/datasim/xapi/profile/activity.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/activity.clj
@@ -78,7 +78,9 @@
 (defn- assoc-activity
   "Associate `activity` to `activity-map`."
   [activity-map activity]
-  (let [{activity-id :id {activity-type-id :type} :definition} activity]
+  (let [{activity-id :id
+         {activity-type-id :type} :activityDefinition}
+        activity]
     (assoc-in activity-map
               [activity-type-id activity-id]
               (profile->statement-activity activity))))
@@ -158,3 +160,15 @@
     (-> {}
         (reduce-activities concept-activities)
         (reduce-act-type-ids activity-type-ids))))
+
+(comment
+  (create-activity-map
+   {"Activity"
+    {"http://profiles.afrl.af.mil/elements/airsense"
+     {:id "http://profiles.afrl.af.mil/elements/airsense"
+      :type "Activity"
+      :definition {:name {:en "Airsense"}
+                   :definition {:en "Recognizes..."}
+                   :type "http://profiles.afrl.af.mil/elements"}}}}
+   100)
+  )

--- a/src/main/com/yetanalytics/datasim/xapi/profile/activity.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/profile/activity.clj
@@ -68,12 +68,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- profile->statement-activity
-  [{:keys [id definition]}]
+  [{:keys [id activityDefinition]}]
   (cond-> {"id" id}
-    definition
-    (assoc "definition" (-> definition
-                            (dissoc definition :_context)
-                            w/stringify-keys))))
+    activityDefinition
+    (assoc "definition"
+           (-> activityDefinition (dissoc :_context) w/stringify-keys))))
 
 (defn- assoc-activity
   "Associate `activity` to `activity-map`."
@@ -160,15 +159,3 @@
     (-> {}
         (reduce-activities concept-activities)
         (reduce-act-type-ids activity-type-ids))))
-
-(comment
-  (create-activity-map
-   {"Activity"
-    {"http://profiles.afrl.af.mil/elements/airsense"
-     {:id "http://profiles.afrl.af.mil/elements/airsense"
-      :type "Activity"
-      :definition {:name {:en "Airsense"}
-                   :definition {:en "Recognizes..."}
-                   :type "http://profiles.afrl.af.mil/elements"}}}}
-   100)
-  )

--- a/src/main/com/yetanalytics/datasim/xapi/rule.clj
+++ b/src/main/com/yetanalytics/datasim/xapi/rule.clj
@@ -9,6 +9,7 @@
             [clojure.string                 :as cstr]
             [clojure.spec.alpha             :as s]
             [clojure.test.check.generators  :as gen]
+            [clojure.walk                   :as w]
             [xapi-schema.spec               :as xs]
             [com.yetanalytics.pathetic      :as path]
             [com.yetanalytics.pathetic.path :as jpath]
@@ -206,9 +207,9 @@
   (let [paths (cond-> (parse-json-path location)
                 selector
                 (join-location-and-selector (parse-json-path selector)))
-        ?any  (not-empty (set any))
-        ?all  (not-empty (set all))
-        ?none (not-empty (set none))]
+        ?any  (not-empty (set (map w/stringify-keys any)))
+        ?all  (not-empty (set (map w/stringify-keys all)))
+        ?none (not-empty (set (map w/stringify-keys none)))]
     (cond-> {:location paths}
       presence       (assoc :presence (keyword presence))
       (or ?any ?all) (assoc :valueset (rule-value-set ?any ?all ?none))

--- a/src/test/com/yetanalytics/datasim/input/profile_test.clj
+++ b/src/test/com/yetanalytics/datasim/input/profile_test.clj
@@ -96,11 +96,11 @@
                   count))))
   (testing "fixed / valid profiles"
     (is (nil? (profile/validate-profiles [const/acrossx-profile])))
-    (is (nil? (profile/validate-profiles [const/activity-profile])))
+    (is (nil? (profile/validate-profiles [const/activity-streams-profile])))
     (is (nil? (profile/validate-profiles [const/tc3-profile]))))
   ;; Following tests exist to point out flaws in Profiles
   (testing "invalid profiles"
     ;; AcrossX and ActivityStreams violate spec:
     ;; "related MUST only be used on deprecated Concepts"
     (is (some? (profile/validate-profiles [const/acrossx-profile*])))
-    (is (some? (profile/validate-profiles [const/activity-profile*])))))
+    (is (some? (profile/validate-profiles [const/activity-streams-profile*])))))

--- a/src/test/com/yetanalytics/datasim/test_constants.clj
+++ b/src/test/com/yetanalytics/datasim/test_constants.clj
@@ -22,10 +22,12 @@
   "dev-resources/profiles/acrossx/profile.jsonld")
 (def acrossx-profile-filepath
   "dev-resources/profiles/acrossx/fixed.jsonld")
-(def activity-profile-filepath*
+(def activity-streams-profile-filepath*
   "dev-resources/profiles/activity_streams/profile.jsonld")
-(def activity-profile-filepath
+(def activity-streams-profile-filepath
   "dev-resources/profiles/activity_streams/fixed.jsonld")
+(def activity-profile-filepath
+  "dev-resources/profiles/activity.jsonld")
 (def mom-profile-filepath
   "dev-resources/profiles/tla/mom.jsonld")
 (def referential-profile-filepath
@@ -108,8 +110,11 @@
 (def acrossx-profile
   (input/from-location :profile :json acrossx-profile-filepath))
 
-(def activity-profile*
-  (input/from-location :profile :json activity-profile-filepath*))
+(def activity-streams-profile*
+  (input/from-location :profile :json activity-streams-profile-filepath*))
+
+(def activity-streams-profile
+  (input/from-location :profile :json activity-streams-profile-filepath))
 
 (def activity-profile
   (input/from-location :profile :json activity-profile-filepath))

--- a/src/test/com/yetanalytics/datasim/xapi/profile_test.clj
+++ b/src/test/com/yetanalytics/datasim/xapi/profile_test.clj
@@ -76,33 +76,46 @@
 
 (def activity-profile
   {:id "http://example.org/activity-profile"
-   :concepts [{:id                 "http://example.org/activity-with-type"
-               :type               "Activity"
-               :activityDefinition {:type "http://example.org/activity-type-1"}}
+   :concepts [{:id   "http://example.org/activity-with-type"
+               :type "Activity"
+               :activityDefinition {:name {:en "Typed Activity"}
+                                    :type "http://example.org/activity-type-1"}}
               {:id   "http://example.org/activity-without-type"
-               :type "Activity"}
+               :type "Activity"
+               :activityDefinition {:name {:en "Non-typed Activity"}}}
               {:id   "http://example.org/activity-type-1"
                :type "ActivityType"}
               {:id   "http://example.org/activity-type-2"
                :type "ActivityType"}
               {:id   "http://example.org/activity-type-3"
                :type "ActivityType"}]
-   :templates [{:id "http://example.org/template"
+   :templates [{:id "http://example.org/template-1"
                 :objectActivityType "http://example.org/activity-type-1"}
-               {:id "http://example.org/template"
+               {:id "http://example.org/template-2"
                 :rules [{:location "$.object.definition.type"
                          :all ["http://example.org/activity-type-1"]}
                         {:location "$.object.definition"
-                         :all [{:type "http://example.org/activity-type-1"}]}]}]})
+                         :all [{:type "http://example.org/activity-type-1"}]}]}
+               {:id "http://example.org/template-3"
+                :rules [{:location "$.object.id"
+                         :all ["http://example.org/activity-with-type"]}]}
+               {:id "http://example.org/template-4"
+                :rules [{:location "$.object.definition.type"
+                         :all ["http://example.org/activity-type-not-exists"]}]}
+               {:id "http://example.org/template-5" ; not added at this step
+                :rules [{:location "$.object.id"    ; added during statement healing
+                         :all ["http://example.org/activity-not-exists"]}]}]})
 
 (def expected-activity-map
   {nil
    {"http://example.org/activity-without-type"
-    {"id" "http://example.org/activity-without-type"}}
+    {"id" "http://example.org/activity-without-type"
+     "definition" {"name" {"en" "Non-typed Activity"}}}}
    "http://example.org/activity-type-1"
    {"http://example.org/activity-with-type"
     {"id" "http://example.org/activity-with-type"
-     "definition" {"type" "http://example.org/activity-type-1"}}}
+     "definition" {"name" {"en" "Typed Activity"}
+                   "type" "http://example.org/activity-type-1"}}}
    "http://example.org/activity-type-2"
    {"https://example.org/activity/418707894"
     {"id"         "https://example.org/activity/418707894"
@@ -110,7 +123,11 @@
    "http://example.org/activity-type-3"
    {"https://example.org/activity/1432714272"
     {"id" "https://example.org/activity/1432714272"
-     "definition" {"type" "http://example.org/activity-type-3"}}}})
+     "definition" {"type" "http://example.org/activity-type-3"}}}
+   "http://example.org/activity-type-not-exists"
+   {"https://example.org/activity/1671689032"
+    {"id" "https://example.org/activity/1671689032"
+     "definition" {"type" "http://example.org/activity-type-not-exists"}}}})
 
 (deftest activity-map-test
   (testing "Activity Map creation"

--- a/src/test/com/yetanalytics/datasim/xapi/profile_test.clj
+++ b/src/test/com/yetanalytics/datasim/xapi/profile_test.clj
@@ -76,9 +76,9 @@
 
 (def activity-profile
   {:id "http://example.org/activity-profile"
-   :concepts [{:id         "http://example.org/activity-with-type"
-               :type       "Activity"
-               :definition {:type "http://example.org/activity-type-1"}}
+   :concepts [{:id                 "http://example.org/activity-with-type"
+               :type               "Activity"
+               :activityDefinition {:type "http://example.org/activity-type-1"}}
               {:id   "http://example.org/activity-without-type"
                :type "Activity"}
               {:id   "http://example.org/activity-type-1"

--- a/src/test/com/yetanalytics/datasim_test.clj
+++ b/src/test/com/yetanalytics/datasim_test.clj
@@ -205,7 +205,23 @@
                  (take-while (partial first-reg? first-fred))
                  (reduce reduce-sats [[]])
                  (every? (fn [sat-stmts]
-                           (<= (count sat-stmts) 100)))))))))
+                           (<= (count sat-stmts) 100))))))))
+  (testing "Respects activity + activity type references within profile"
+    (let [input  (assoc const/simple-input :profiles [const/activity-profile])
+          result (->> (get (generate-map input) alice-mbox) (take 4) vec)]
+      (is (= {"id" "https://xapinet.org/xapi/yet/activity/typed",
+              "definition"
+              {"name"        {"en" "Activity with Activity Type"},
+               "description" {"en" "Activity with Activity Type"},
+               "type"        "https://xapinet.org/xapi/yet/activity-type"}}
+             (-> result (get 0) (get "object"))
+             (-> result (get 1) (get "object"))
+             (-> result (get 2) (get "object"))))
+      (is (= {"id" "https://xapinet.org/xapi/yet/activity/nontyped",
+              "definition"
+              {"name"        {"en" "Activity without Activity Type"},
+               "description" {"en" "Activity without Activity Type"}}}
+             (-> result (get 3) (get "object")))))))
 
 (deftest generate-seq-test
   (testing "Returns statements"

--- a/src/test/com/yetanalytics/datasim_test.clj
+++ b/src/test/com/yetanalytics/datasim_test.clj
@@ -214,14 +214,27 @@
               {"name"        {"en" "Activity with Activity Type"},
                "description" {"en" "Activity with Activity Type"},
                "type"        "https://xapinet.org/xapi/yet/activity-type"}}
-             (-> result (get 0) (get "object"))
-             (-> result (get 1) (get "object"))
-             (-> result (get 2) (get "object"))))
+             (-> result (get 0) (get-in ["object"]))
+             (-> result (get 0) (get-in ["context" "contextActivities" "category" 0]))
+             (-> result (get 0) (get-in ["context" "contextActivities" "grouping" 0]))
+             (-> result (get 0) (get-in ["context" "contextActivities" "parent" 0]))
+             (-> result (get 0) (get-in ["context" "contextActivities" "other" 0]))
+             (-> result (get 1) (get-in ["object"]))
+             (-> result (get 1) (get-in ["context" "contextActivities" "grouping" 0]))
+             (-> result (get 1) (get-in ["context" "contextActivities" "parent" 0]))
+             (-> result (get 1) (get-in ["context" "contextActivities" "other" 0]))
+             (-> result (get 2) (get-in ["object"]))
+             (-> result (get 2) (get-in ["context" "contextActivities" "grouping" 0]))
+             (-> result (get 2) (get-in ["context" "contextActivities" "parent" 0]))
+             (-> result (get 2) (get-in ["context" "contextActivities" "other" 0]))))
       (is (= {"id" "https://xapinet.org/xapi/yet/activity/nontyped",
               "definition"
               {"name"        {"en" "Activity without Activity Type"},
                "description" {"en" "Activity without Activity Type"}}}
-             (-> result (get 3) (get "object")))))))
+             (-> result (get 3) (get-in ["object"]))
+             (-> result (get 3) (get-in ["context" "contextActivities" "grouping" 0]))
+             (-> result (get 3) (get-in ["context" "contextActivities" "parent" 0]))
+             (-> result (get 3) (get-in ["context" "contextActivities" "other" 0])))))))
 
 (deftest generate-seq-test
   (testing "Returns statements"


### PR DESCRIPTION
Fix a number of bugs associated with Activity and Activity Type generation
- Fix places where `:definition` was used in place of `:activityDefinition` when destructing Activities found in xAPI Profiles. This caused Activities to not be associated with their respective Activity Types.
- Fix keys not being stringified in map values for rule `any`, `all`, and `none`.